### PR TITLE
Complete rewrite of bittorrent structure

### DIFF
--- a/bittorrent/examples/download.rs
+++ b/bittorrent/examples/download.rs
@@ -14,12 +14,11 @@ fn main() {
     let torrent =
         lava_torrent::torrent::v1::Torrent::read_from_file("assets/test-file-1.torrent").unwrap();
     tokio_uring::start(async move {
-        let torrent_manager = TorrentManager::new("assets/test-file-1.torrent").await;
-        let _peer_con = torrent_manager
-            .add_peer("172.17.0.2:51413".parse().unwrap())
-            .await
-            .unwrap();
-        log::info!("We are connected!!");
+        let mut torrent_manager = TorrentManager::new("assets/test-file-1.torrent").await;
+        let peer_list = torrent_manager.peer_list_handle();
+        peer_list.insert("172.17.0.3:51413".parse().unwrap());
+
+        log::info!("We are attempting a connection");
 
         println!("Total length: {}", torrent.length);
         println!("pieces: {}", torrent.pieces.len());
@@ -27,7 +26,7 @@ fn main() {
         // 1. 766s (with spawning write in separate task)
         // 2. 766s (without spawning write in separate task)
         let download_time = Instant::now();
-        torrent_manager.start().await.unwrap();
+        torrent_manager.download_complete().await;
         let elapsed = download_time.elapsed();
         log::info!("Download complete in: {}s", elapsed.as_secs());
 

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -234,7 +234,14 @@ impl TorrentState {
                 self.file_store.write_piece(index, data).await.unwrap();
 
                 // Purge disconnected peers 
-                let mut disconnected_peers:Vec<PeerKey> = self.peer_list.connections.iter().filter_map(|(peer_key,peer)| peer.have(index).map(|_| peer_key).ok()).collect();
+                let mut disconnected_peers:Vec<PeerKey> = self.peer_list.connections.iter()
+                    .filter_map(|(peer_key,peer)| {
+                        if peer.have(index).is_err() {
+                            Some(peer_key)
+                        } else {
+                            None
+                        }
+                    }).collect();
 
                 if self.piece_selector.completed_all() {
                     log::info!("Torrent completed!");
@@ -272,7 +279,7 @@ impl TorrentState {
                         }
                     }
                 }
-                if requested_piece {
+                if !requested_piece {
                     log::error!("No piece can be downloaded from any peer");
                 }
                self

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -333,7 +333,7 @@ impl TorrentState {
                 // TODO handle this more gracefully
                 assert_eq!(&info_hash, self.torrent_info.info_hash_bytes().as_slice());
                 log::info!("Handshake received");
-                // TODO: update peer list here
+                peer_connection.interested()?;
             }
             PeerEventType::Choked => {
                 let peer_connection = connection_mut_or_return!();

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -282,7 +282,7 @@ impl TorrentState {
                         // only peers that haven't choked us and that aren't currently downloading. 
                         // At least one peer must be available here to download, it might not have
                         // the desired piece though.
-                        let peer_connections = self.peer_list.peer_connection_states.borrow();
+                        /*let peer_connections = self.peer_list.peer_connection_states.borrow();
                         for (peer_key,peer) in peer_connections.iter().filter(|(_,peer)| !peer.state().peer_choking && peer.state().currently_downloading.is_none()) {
                             if peer.state().peer_pieces[next_piece as usize] {
                                 if peer.state().is_choking {
@@ -304,7 +304,7 @@ impl TorrentState {
                                     return;
                                 }
                             }
-                        }
+                        }*/
                     } else {
                        log::error!("No piece can be downloaded from any peer"); 
                         return;

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -3,7 +3,7 @@
 // which requires support for http://www.bittorrent.org/beps/bep_0010.html
 // which needs the foundational http://www.bittorrent.org/beps/bep_0003.html implementation
 
-use std::{net::SocketAddr, path::Path, sync::Arc, time::Instant, borrow::BorrowMut};
+use std::{borrow::BorrowMut, net::SocketAddr, path::Path, sync::Arc, time::Instant};
 
 use anyhow::Context;
 use bitvec::prelude::*;

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -191,10 +191,11 @@ async fn process_incoming(
             }
         }
         PeerMessage::Handshake { peer_id, info_hash } => {
+            // TODO: Check if handshake was pending?
             peer_event_sender
                 .send(PeerEvent {
                     peer_key,
-                    event_type: PeerEventType::Intrest,
+                    event_type: PeerEventType::HandshakeComplete { peer_id, info_hash },
                 })
                 .await?;
         }

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -61,12 +61,12 @@ impl PeerConnectionState {
 async fn process_incoming(
     peer_key: PeerKey,
     msg: PeerMessage,
-    peer_event_sender: tokio::sync::mpsc::Sender<PeerEvent>,
-    // Get rid of rc refcell?
-    currently_downloading: Rc<RefCell<Option<Piece>>>,
+    peer_event_sender: &tokio::sync::mpsc::Sender<PeerEvent>,
+    // TODO: Get rid of rc refcell?
+    currently_downloading: &Rc<RefCell<Option<Piece>>>,
     // TODO: This is unnecessary and should be replaced
     // with writing directly to the socket
-    outgoing_tx: UnboundedSender<PeerMessage>,
+    outgoing_tx: &UnboundedSender<PeerMessage>,
 ) -> anyhow::Result<()> {
     match msg {
         PeerMessage::Choke => {
@@ -204,8 +204,6 @@ async fn process_incoming(
     Ok(())
 }
 
-
-
 fn start_network_thread(
     peer_key: PeerKey,
     sendable_stream: SendableStream,
@@ -301,7 +299,7 @@ fn start_network_thread(
                             Ok(bytes_read) => {
                                 let remainder = read_buf.split_off(bytes_read);
                                 while let Some(message) = message_decoder.decode(&mut read_buf) {
-                                    if process_incoming(peer_key, message, peer_event_sender, currently_downloading, outgoing_tx_clone).await.is_err() {
+                                    if process_incoming(peer_key, message, &peer_event_sender, &currently_downloading, &outgoing_tx_clone).await.is_err() {
                                         log::error!("No one is listening for incoming traffic, channel dropped");
                                     }
                                 }
@@ -332,7 +330,6 @@ pub struct PeerConnection {
 }
 
 impl PeerConnection {
-    
     pub fn new(
         peer_key: PeerKey,
         num_pieces: usize,

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -268,7 +268,7 @@ fn start_network_thread(
                         // and writes less if no more msgs are incoming
                         outgoing.encode(&mut send_buf);
                     }
-                    // Write all since the buffer has only been filled with encoded data 
+                    // Write all since the buffer has only been filled with encoded data
                     let (result, buf) = stream_clone.write_all(send_buf).await;
                     send_buf = buf;
                     // Need to prevent resending the same message

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -46,7 +46,6 @@ impl PeerConnectionState {
         Self {
             is_choking: true,
             is_interested: false,
-            // TODO: is this correct?
             peer_choking: true,
             peer_interested: false,
             peer_pieces,
@@ -95,6 +94,9 @@ fn start_network_thread(
             let sendable_stream = sendable_stream;
             let stream = Rc::new(sendable_stream.0);
             let stream_clone = stream.clone();
+
+            // Om man använder tokio_select! här istället så kan man ha hela statet i den här
+            // tråden typ
 
             // Send loop, should be cancelled automatically in the next iteration when outgoing_rc is dropped.
             tokio_uring::spawn(async move {

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -229,7 +229,7 @@ fn start_network_thread(
                 while let Some(outgoing) = outgoing_rc.recv().await {
                     if let PeerMessage::Request {
                         index,
-                        begin,
+                        begin: _,
                         length,
                     } = outgoing
                     {
@@ -345,17 +345,6 @@ impl PeerConnection {
             state: PeerConnectionState::new(cancellation_token),
             outgoing: outgoing_tx,
         };
-
-        // process incoming, should cancel automatically when incoming_tx is dropped
-        /*tokio_uring::spawn(async move {
-            while let Some(incoming) = incoming_rc.recv().await {
-                    process_incoming(incoming, &mut torrent_state)
-                    .await
-                {
-                    log::error!("[Peer: {peer_id:?}] Error processing incoming message: {err}");
-                }
-            }
-        });*/
 
         Ok(connection)
     }

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,4 +1,4 @@
-use crate::{Piece, PeerKey};
+use crate::{PeerKey, Piece};
 
 #[derive(Debug)]
 pub enum PeerEventType {
@@ -9,22 +9,22 @@ pub enum PeerEventType {
     /// The peer is interested in us
     Intrest,
     /// The peer is not interested in us
-    NotInterested, 
+    NotInterested,
     /// Peer requests a piece
-    PieceRequest {
-        index: i32,
-        begin: i32,
-        length: i32,
-    },
+    PieceRequest { index: i32, begin: i32, length: i32 },
     /// Piece request completed
     PieceRequestSucceeded(Piece),
     /// Piece request failed
     PieceRequestFailed,
-    // TODO: Handshake complete/failed?
+    /// Connection handshake completed succesfully
+    HandshakeComplete {
+        peer_id: [u8; 20],
+        // TODO: Perhaps this can be checked before this is sent?
+        info_hash: [u8; 20],
+    }, 
+    // TODO: handshake failed
     // TODO: peer stats
 }
-
-
 
 #[derive(Debug)]
 pub struct PeerEvent {

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, net::SocketAddr};
 
-use bitvec::prelude::{BitBox, Msb0};
+use bitvec::{prelude::Msb0, vec::BitVec};
 
 use crate::{PeerKey, Piece};
 
@@ -19,7 +19,7 @@ pub enum PeerEventType {
         index: i32,
     },
     /// Peer pieces
-    Bitfield(BitBox<u8, Msb0>),
+    Bitfield(BitVec<u8, Msb0>),
     /// Peer requests a piece
     PieceRequest {
         index: i32,

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,0 +1,33 @@
+use crate::Piece;
+
+#[derive(Debug)]
+pub enum PeerEventType {
+    /// We were choked by the peer
+    Choked,
+    /// Unchoke from a peer we are interested in
+    InterestingUnchoke,
+    /// The peer is interested in us
+    Intrest,
+    /// The peer is not interested in us
+    NotInterested, 
+    /// Peer requests a piece
+    PieceRequest {
+        index: i32,
+        begin: i32,
+        length: i32,
+    },
+    /// Piece request completed
+    PieceRequestSucceeded(Piece),
+    /// Piece request failed
+    PieceRequestFailed,
+    // TODO: Handshake complete/failed?
+    // TODO: peer stats
+}
+
+
+
+#[derive(Debug)]
+pub struct PeerEvent {
+    pub peer_id: [u8; 20],
+    pub event_type: PeerEventType,
+}

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, net::SocketAddr};
 
+use bitvec::prelude::{BitBox, Msb0};
 use tokio_uring::net::TcpStream;
 
 use crate::{PeerKey, Piece};
@@ -8,11 +9,11 @@ use crate::{PeerKey, Piece};
 // have been cloned at this point and importantly
 // there are not inflight operations at this point
 //
-// TODO safety here is a bit more unclear but should be possible to 
+// TODO safety here is a bit more unclear but should be possible to
 // remove this all together when accept_incoming case is handled
 pub struct SendableStream(pub TcpStream);
 unsafe impl Send for SendableStream {}
-// this is temporary and only necessary for error handling afaik 
+// this is temporary and only necessary for error handling afaik
 unsafe impl Sync for SendableStream {}
 
 impl Debug for SendableStream {
@@ -31,6 +32,10 @@ pub enum PeerEventType {
     Intrest,
     /// The peer is not interested in us
     NotInterested,
+    /// Peer have downloaded a piece
+    Have { index: i32 },
+    /// Peer pieces
+    Bitfield(BitBox<u8, Msb0>),
     /// Peer requests a piece
     PieceRequest { index: i32, begin: i32, length: i32 },
     /// Piece request completed

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -4,8 +4,8 @@ use crate::{Piece, PeerKey};
 pub enum PeerEventType {
     /// We were choked by the peer
     Choked,
-    /// Unchoke from a peer we are interested in
-    InterestingUnchoke,
+    /// Unchoke
+    Unchoke,
     /// The peer is interested in us
     Intrest,
     /// The peer is not interested in us

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,26 +1,8 @@
 use std::{fmt::Debug, net::SocketAddr};
 
 use bitvec::prelude::{BitBox, Msb0};
-use tokio_uring::net::TcpStream;
 
 use crate::{PeerKey, Piece};
-
-// Safe since the inner Rc have yet to
-// have been cloned at this point and importantly
-// there are not inflight operations at this point
-//
-// TODO safety here is a bit more unclear but should be possible to
-// remove this all together when accept_incoming case is handled
-pub struct SendableStream(pub TcpStream);
-unsafe impl Send for SendableStream {}
-// this is temporary and only necessary for error handling afaik
-unsafe impl Sync for SendableStream {}
-
-impl Debug for SendableStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SendableStream").finish()
-    }
-}
 
 #[derive(Debug)]
 pub enum PeerEventType {
@@ -33,11 +15,17 @@ pub enum PeerEventType {
     /// The peer is not interested in us
     NotInterested,
     /// Peer have downloaded a piece
-    Have { index: i32 },
+    Have {
+        index: i32,
+    },
     /// Peer pieces
     Bitfield(BitBox<u8, Msb0>),
     /// Peer requests a piece
-    PieceRequest { index: i32, begin: i32, length: i32 },
+    PieceRequest {
+        index: i32,
+        begin: i32,
+        length: i32,
+    },
     /// Piece request completed
     PieceRequestSucceeded(Piece),
     /// Piece request failed
@@ -50,9 +38,8 @@ pub enum PeerEventType {
     },
     // These sorts of events should probably live outside this particular enum
     // this + start + stop + total stats? probably lives better somewhere else
+    // connect fail could be another event
     NewConnection {
-        // Skip this all together?
-        stream: SendableStream,
         addr: SocketAddr,
     },
     // TODO: handshake failed

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -8,11 +8,11 @@ use crate::{PeerKey, Piece};
 // have been cloned at this point and importantly
 // there are not inflight operations at this point
 //
-// TODO safety here is a bit more unclear but should be possible to
+// TODO safety here is a bit more unclear but should be possible to 
 // remove this all together when accept_incoming case is handled
 pub struct SendableStream(pub TcpStream);
 unsafe impl Send for SendableStream {}
-// this is temporary and only necessary for error handling afaik
+// this is temporary and only necessary for error handling afaik 
 unsafe impl Sync for SendableStream {}
 
 impl Debug for SendableStream {
@@ -43,6 +43,8 @@ pub enum PeerEventType {
         // TODO: Perhaps this can be checked before this is sent?
         info_hash: [u8; 20],
     },
+    // These sorts of events should probably live outside this particular enum
+    // this + start + stop + total stats? probably lives better somewhere else
     NewConnection {
         // Skip this all together?
         stream: SendableStream,

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -1,4 +1,4 @@
-use crate::Piece;
+use crate::{Piece, PeerKey};
 
 #[derive(Debug)]
 pub enum PeerEventType {
@@ -28,6 +28,6 @@ pub enum PeerEventType {
 
 #[derive(Debug)]
 pub struct PeerEvent {
-    pub peer_id: [u8; 20],
+    pub peer_key: PeerKey,
     pub event_type: PeerEventType,
 }

--- a/bittorrent/src/peer_events.rs
+++ b/bittorrent/src/peer_events.rs
@@ -8,11 +8,11 @@ use crate::{PeerKey, Piece};
 // have been cloned at this point and importantly
 // there are not inflight operations at this point
 //
-// TODO safety here is a bit more unclear but should be possible to 
+// TODO safety here is a bit more unclear but should be possible to
 // remove this all together when accept_incoming case is handled
 pub struct SendableStream(pub TcpStream);
 unsafe impl Send for SendableStream {}
-// this is temporary and only necessary for error handling afaik 
+// this is temporary and only necessary for error handling afaik
 unsafe impl Sync for SendableStream {}
 
 impl Debug for SendableStream {

--- a/bittorrent/src/peer_message.rs
+++ b/bittorrent/src/peer_message.rs
@@ -4,15 +4,33 @@ use bytes::{Buf, BufMut, Bytes};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PeerMessage {
+    Handshake {
+        peer_id: [u8; 20],
+        info_hash: [u8; 20],
+    },
     Choke,
     Unchoke,
     Interested,
     NotInterested,
-    Have { index: i32 },
+    Have {
+        index: i32,
+    },
     Bitfield(BitBox<u8, Msb0>),
-    Request { index: i32, begin: i32, length: i32 },
-    Cancel { index: i32, begin: i32, length: i32 },
-    Piece { index: i32, begin: i32, data: Bytes },
+    Request {
+        index: i32,
+        begin: i32,
+        length: i32,
+    },
+    Cancel {
+        index: i32,
+        begin: i32,
+        length: i32,
+    },
+    Piece {
+        index: i32,
+        begin: i32,
+        data: Bytes,
+    },
 }
 
 impl PeerMessage {
@@ -26,6 +44,7 @@ impl PeerMessage {
     pub const PIECE: u8 = 7;
     pub const CANCEL: u8 = 8;
 
+    // TODO: make use of me outside fuzzing
     pub fn encoded_size(&self) -> usize {
         match self {
             PeerMessage::Choke
@@ -36,6 +55,7 @@ impl PeerMessage {
             PeerMessage::Bitfield(bitfield) => 1 + bitfield.as_raw_slice().len(),
             PeerMessage::Request { .. } | PeerMessage::Cancel { .. } => 13,
             PeerMessage::Piece { data, .. } => 13 + data.len(),
+            PeerMessage::Handshake { .. } => 68,
         }
     }
 
@@ -96,6 +116,14 @@ impl PeerMessage {
                 buf.put_i32(begin);
                 buf.put(data);
             }
+            PeerMessage::Handshake { peer_id, info_hash } => {
+                const PROTOCOL: &[u8] = b"BitTorrent protocol";
+                buf.put_u8(PROTOCOL.len() as u8);
+                buf.put(PROTOCOL);
+                buf.put(&[0_u8; 8] as &[u8]);
+                buf.put(&info_hash as &[u8]);
+                buf.put(&peer_id as &[u8]);
+            }
         }
     }
 }
@@ -149,10 +177,21 @@ impl<'a> Arbitrary<'a> for PeerMessage {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PeerMessageDecoder {
     length: Option<i32>,
     data: Bytes,
+    pending_handshake: bool,
+}
+
+impl Default for PeerMessageDecoder {
+    fn default() -> Self {
+        Self {
+            length: Default::default(),
+            data: Default::default(),
+            pending_handshake: true,
+        }
+    }
 }
 
 impl PeerMessageDecoder {
@@ -188,6 +227,27 @@ impl PeerMessageDecoder {
                     }
                 }
                 None => {
+                    if self.pending_handshake && data.remaining() >= 68 {
+                        // TODO Move me and don't return errors here send handshake fail event
+                        let str_len = data.get_u8();
+                        //anyhow::ensure!(str_len == 19);
+                        assert!(str_len == 19);
+                        assert!(
+                            data.chunk().get(..str_len as usize) == Some(b"BitTorrent protocol" as &[u8])
+                        );
+                        data.advance(str_len as usize);
+                        // Skip extensions for now
+                        data.advance(8);
+                        let info_hash = &data.chunk()[..20];
+                        data.advance(20_usize);
+                        let peer_id = &data.chunk()[..20];
+                        data.advance(20_usize);
+                        self.pending_handshake = false;
+                        break Some(PeerMessage::Handshake {
+                            peer_id: peer_id.try_into().unwrap(),
+                            info_hash: info_hash.try_into().unwrap(),
+                        });
+                    }
                     if data.remaining() >= std::mem::size_of::<i32>() {
                         let msg_length = data.get_i32();
                         if msg_length > 0 {

--- a/bittorrent/src/peer_message.rs
+++ b/bittorrent/src/peer_message.rs
@@ -233,20 +233,18 @@ impl PeerMessageDecoder {
                         //anyhow::ensure!(str_len == 19);
                         assert!(str_len == 19);
                         assert!(
-                            data.chunk().get(..str_len as usize) == Some(b"BitTorrent protocol" as &[u8])
+                            data.chunk().get(..str_len as usize)
+                                == Some(b"BitTorrent protocol" as &[u8])
                         );
                         data.advance(str_len as usize);
                         // Skip extensions for now
                         data.advance(8);
-                        let info_hash = &data.chunk()[..20];
+                        let info_hash = data.chunk()[..20].try_into().unwrap();
                         data.advance(20_usize);
-                        let peer_id = &data.chunk()[..20];
+                        let peer_id = data.chunk()[..20].try_into().unwrap();
                         data.advance(20_usize);
                         self.pending_handshake = false;
-                        break Some(PeerMessage::Handshake {
-                            peer_id: peer_id.try_into().unwrap(),
-                            info_hash: info_hash.try_into().unwrap(),
-                        });
+                        break Some(PeerMessage::Handshake { peer_id, info_hash });
                     }
                     if data.remaining() >= std::mem::size_of::<i32>() {
                         let msg_length = data.get_i32();

--- a/bittorrent/src/peer_message.rs
+++ b/bittorrent/src/peer_message.rs
@@ -85,7 +85,7 @@ impl PeerMessage {
             PeerMessage::Bitfield(bitfield) => {
                 buf.put_i32(1 + bitfield.as_raw_slice().len() as i32);
                 buf.put_u8(Self::BITFIELD);
-                buf.put(bitfield.as_raw_slice());
+                buf.put_slice(bitfield.as_raw_slice());
             }
             PeerMessage::Request {
                 index,
@@ -114,15 +114,15 @@ impl PeerMessage {
                 buf.put_u8(Self::PIECE);
                 buf.put_i32(index);
                 buf.put_i32(begin);
-                buf.put(data);
+                buf.put_slice(&data);
             }
             PeerMessage::Handshake { peer_id, info_hash } => {
                 const PROTOCOL: &[u8] = b"BitTorrent protocol";
                 buf.put_u8(PROTOCOL.len() as u8);
-                buf.put(PROTOCOL);
-                buf.put(&[0_u8; 8] as &[u8]);
-                buf.put(&info_hash as &[u8]);
-                buf.put(&peer_id as &[u8]);
+                buf.put_slice(PROTOCOL);
+                buf.put_slice(&[0_u8; 8] as &[u8]);
+                buf.put_slice(&info_hash as &[u8]);
+                buf.put_slice(&peer_id as &[u8]);
             }
         }
     }

--- a/bittorrent/src/peer_message.rs
+++ b/bittorrent/src/peer_message.rs
@@ -15,7 +15,7 @@ pub enum PeerMessage {
     Have {
         index: i32,
     },
-    Bitfield(BitBox<u8, Msb0>),
+    Bitfield(BitVec<u8, Msb0>),
     Request {
         index: i32,
         begin: i32,
@@ -143,7 +143,7 @@ impl<'a> Arbitrary<'a> for PeerMessage {
             PeerMessage::BITFIELD => {
                 let vec = u.arbitrary::<Vec<u8>>()?;
                 let bits = BitVec::<_, Msb0>::from_slice(&vec);
-                Ok(PeerMessage::Bitfield(bits.into_boxed_bitslice()))
+                Ok(PeerMessage::Bitfield(bits))
             }
             PeerMessage::REQUEST => {
                 let index = u.arbitrary()?;
@@ -283,7 +283,7 @@ pub fn parse_message(data: &mut impl Buf, length: i32) -> anyhow::Result<PeerMes
             let mut bitfield = vec![0; length as usize - 1];
             data.copy_to_slice(&mut bitfield);
             let bits = BitVec::<_, Msb0>::from_slice(&bitfield);
-            Ok(PeerMessage::Bitfield(bits.into_boxed_bitslice()))
+            Ok(PeerMessage::Bitfield(bits))
         }
         PeerMessage::REQUEST => {
             anyhow::ensure!(length >= 13);

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -156,6 +156,4 @@ impl PieceSelector {
             self.piece_length
         }
     }
-
-    // TODO consider actually triggering the piece download from this struct?
 }

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -75,6 +75,7 @@ impl PieceSelector {
             log::warn!("Random piece selection failed");
             available_pieces.first_one().map(|index| index as i32)
         } else {
+            // TODO: This must take into accouint all peer pieces
             // Rarest first
             let mut count = vec![0; available_pieces.len()];
             for available in available_pieces.iter_ones() {

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -50,7 +50,7 @@ impl PieceSelector {
         let mut available_pieces: BitBox<u8, Msb0> =
             (0..self.completed_pieces.len()).map(|_| false).collect();
 
-        let peer_connections = peer_list.peer_connection_states.borrow();
+        let peer_connections = &peer_list.connections;
         for (_, peer) in peer_connections.iter() {
             available_pieces |= &peer.state().peer_pieces;
         }

--- a/bittorrent/tests/end_to_end.rs
+++ b/bittorrent/tests/end_to_end.rs
@@ -1,6 +1,3 @@
-use std::time::Duration;
-
-use tokio_uring::net::TcpListener;
 use vortex_bittorrent::TorrentManager;
 
 // Make these tests automatic

--- a/bittorrent/tests/end_to_end.rs
+++ b/bittorrent/tests/end_to_end.rs
@@ -14,17 +14,14 @@ fn download_from_seeding() {
         .try_init();
     let torrent = lava_torrent::torrent::v1::Torrent::read_from_file("final_test.torrent").unwrap();
     tokio_uring::start(async move {
-        let torrent_manager = TorrentManager::new("final_test.torrent").await;
-        let _peer_con = torrent_manager
-            .add_peer("127.0.0.1:6881".parse().unwrap())
-            .await
-            .unwrap();
-        log::info!("We are connected!!");
+        let mut torrent_manager = TorrentManager::new("final_test.torrent").await;
+        let peer_list_handle = torrent_manager.peer_list_handle();
+        peer_list_handle.insert("127.0.0.1:6881".parse().unwrap());
 
         println!("Total length: {}", torrent.length);
         println!("pieces: {}", torrent.pieces.len());
 
-        torrent_manager.start().await.unwrap();
+        torrent_manager.download_complete().await;
 
         let expected = std::fs::read("final_file_og.txt").unwrap();
         let actual = std::fs::read("final_file.txt").unwrap();
@@ -32,7 +29,7 @@ fn download_from_seeding() {
     });
 }
 
-#[test]
+/*#[test]
 #[ignore = "only for ci"]
 fn accepts_incoming() {
     let _ = env_logger::builder()
@@ -71,3 +68,4 @@ fn accepts_incoming() {
         }
     });
 }
+*/

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,12 +35,10 @@ fn main() {
         .init();
 
     tokio_uring::start(async move {
-        let progress = MultiProgress::new();
-
         // TODO Should start dht first
         let torrent_info =
             lava_torrent::torrent::v1::Torrent::read_from_file("slackware.torrent").unwrap();
-        let torrent_manager = TorrentManager::new("slackware.torrent").await;
+        let mut torrent_manager = TorrentManager::new("slackware.torrent").await;
         let info_hash = torrent_info.info_hash_bytes().try_into().unwrap();
         let peer_list_map = Mutex::new(
             [(info_hash, torrent_manager.peer_list_handle())]
@@ -57,74 +55,16 @@ fn main() {
         let mut peers_reciver = dht.find_peers(info_hash.as_ref());
 
         dht.save(Path::new("routing_table.json")).await.unwrap();
-        let peers = peers_reciver.recv().await.unwrap();
-
-        let connection_progress = progress.add(ProgressBar::new_spinner());
-        connection_progress
-            .set_style(ProgressStyle::with_template("{spinner:.blue} {msg}").unwrap());
-        connection_progress.enable_steady_tick(Duration::from_millis(100));
-        let total_peers = peers.len();
-        let num_success = Rc::new(RefCell::new(0));
-        let num_failures = Rc::new(RefCell::new(0));
-
-        let connect_futures = peers.into_iter().enumerate().map(|(i, addr)| {
-            let num_success_clone = num_success.clone();
-            let num_failures_clone = num_failures.clone();
-            let manager_clone = torrent_manager.clone();
-            let connection_progress = connection_progress.clone();
-            tokio_uring::spawn(async move {
-                {
-                    let success = num_success_clone.borrow();
-                    let failures = num_failures_clone.borrow();
-                    connection_progress.set_message(format!(
-                        "Connecting to peer [{i}/{}], Success: {success}, Failures: {failures}",
-                        total_peers
-                    ));
+        let peer_list_handle = torrent_manager.peer_list_handle();
+        tokio_uring::spawn(async move {
+            while let Some(peers) = peers_reciver.recv().await {
+                for peer_addr in peers {
+                    log::info!("Attempting connection to {}", peer_addr);
+                    peer_list_handle.insert(peer_addr);
                 }
-
-                let connect_res =
-                    tokio::time::timeout(Duration::from_secs(5), manager_clone.add_peer(addr))
-                        .await;
-
-                match connect_res {
-                    Ok(Ok(_peer_con)) => {
-                        *num_success_clone.borrow_mut() += 1;
-                        log::info!("Connected to {}!", addr);
-                    }
-                    Ok(Err(err)) => {
-                        *num_failures_clone.borrow_mut() += 1;
-                        log::error!("Failed to connect to peer {}, error: {err}", addr);
-                    }
-                    Err(_) => {
-                        *num_failures_clone.borrow_mut() += 1;
-                        log::error!("Failed to connect to peer: {:?}, timedout", addr);
-                    }
-                }
-                {
-                    let success = num_success_clone.borrow();
-                    let failures = num_failures_clone.borrow();
-                    connection_progress.set_message(format!(
-                        "Connecting to peer [{i}/{}], Success: {success}, Failures: {failures}",
-                        total_peers
-                    ));
-                }
-            })
+            }
         });
 
-        futures::future::join_all(connect_futures).await;
-        connection_progress.finish_with_message(format!(
-            "Connected to {}/{} peers",
-            num_success.borrow(),
-            total_peers
-        ));
-        let download_progress = progress.add(ProgressBar::new(torrent_info.length as u64));
-        download_progress.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})").unwrap().progress_chars("#>-"));
-        let download_progress_clone = download_progress.clone();
-        torrent_manager.set_subpiece_callback(move |data| {
-            download_progress_clone.inc(data.len() as u64);
-        });
-        download_progress.tick();
-        torrent_manager.start().await.unwrap();
-        download_progress.finish_with_message("File dowloaded!");
+        torrent_manager.download_complete().await;
     });
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,5 @@
-use std::{cell::RefCell, path::Path, rc::Rc, time::Duration};
+use std::path::Path;
 
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 use vortex_bittorrent::{PeerListHandle, TorrentManager};
 use vortex_dht::PeerProvider;


### PR DESCRIPTION
Moves over to an event based system with the introduction of `PeerEvents`. Wanted to try other approaches before doing this but clearly this is much simpler to reason about and maintain. Gets rid of multiple `Rc<RefCell<_>>` types since state isn't shared across tasks and gets rid of all unsafe code. It also fixes some bugs when you wanted to wait for unchokes for example. Previously the hack was just  a hardcoded "sleep" which clearly isn't the right approach.