### PR TITLE
Disk IO rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.13.2",
  "windows-targets",
 ]
 
@@ -955,6 +955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,8 +1178,10 @@ dependencies = [
  "libc",
  "log",
  "rand",
+ "rayon",
  "sha1",
  "slab",
+ "smallvec 2.0.0-alpha.10",
  "socket2 0.5.8",
  "thiserror 2.0.11",
 ]

--- a/bittorrent/Cargo.toml
+++ b/bittorrent/Cargo.toml
@@ -20,6 +20,8 @@ rand = { workspace = true }
 lava_torrent = { workspace = true } 
 thiserror = { workspace = true }
 sha1 = { workspace = true }
+smallvec= { version = "2.0.0-alpha.10" , features = ["std"]}
+rayon = "1"
 
 [features]
 fuzzing = ["dep:arbitrary"]

--- a/bittorrent/src/file_store/file.rs
+++ b/bittorrent/src/file_store/file.rs
@@ -1,5 +1,6 @@
 use std::{
     io,
+    num::NonZero,
     os::{fd::AsRawFd, unix::fs::MetadataExt},
     path::Path,
     ptr,
@@ -9,7 +10,17 @@ use std::{
 pub struct MmapFile {
     addr: ptr::NonNull<libc::c_void>,
     len: usize,
+    page_size: usize,
 }
+
+// SAFETY: You can't write to the file witout &mut access to the file except when writing through the ptr.
+// that is only exposed to this module which does it via the WritablePieceFileViews that are
+// themselves unsafe and require that the views do not overlap and are XOR to any readable views
+unsafe impl Sync for MmapFile {}
+
+// SAFETY: There is nothing inherit to the MmapFile struct that can't be sent to other threads
+// safely
+unsafe impl Send for MmapFile {}
 
 impl MmapFile {
     pub fn create(path: impl AsRef<Path>, size: usize) -> io::Result<Self> {
@@ -19,6 +30,11 @@ impl MmapFile {
             .write(true)
             .read(true)
             .open(path)?;
+
+        let page_size = match unsafe { libc::sysconf(libc::_SC_PAGESIZE) } {
+            -1 => panic!("Failed to get page size"),
+            size => size as usize,
+        };
 
         let current_size = file.metadata()?.size();
         if current_size < size as u64 {
@@ -49,24 +65,54 @@ impl MmapFile {
                 addr => {
                     // here, `mmap` will never return null
                     let addr = ptr::NonNull::new_unchecked(addr);
-                    Ok(Self { addr, len: size })
+                    Ok(Self {
+                        addr,
+                        len: size,
+                        page_size,
+                    })
                 }
             }
         }
-    }
-
-    // Deref instead?
-    pub fn get_mut(&mut self) -> &mut [u8] {
-        unsafe { std::slice::from_raw_parts_mut(self.addr.as_ptr() as _, self.len) }
     }
 
     pub fn get(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.addr.as_ptr() as _, self.len) }
     }
 
-    pub fn sync(&self) -> io::Result<()> {
-        let ret = unsafe { libc::msync(self.addr.as_ptr() as _, self.len, libc::MS_SYNC) };
-        if ret != 0 {
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub(super) fn ptr(&self) -> ptr::NonNull<libc::c_void> {
+        self.addr
+    }
+
+    pub fn sync(&self, start: usize, end: usize) -> io::Result<()> {
+        if end <= start || end > self.len {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
+        let unaligned_addr = self.addr.as_ptr() as usize + start;
+        // Addr is already page aligned
+        let page_aligned_ptr = if start == 0 {
+            self.addr
+        } else {
+            self.addr.map_addr(|addr| {
+                let offset = addr.get() + start;
+                // addr is guaranteed to be non zero and something + nonzero is still nonzero
+                unsafe {
+                    debug_assert!(offset.next_multiple_of(self.page_size) - self.page_size > 0);
+                    NonZero::new_unchecked(offset.next_multiple_of(self.page_size) - self.page_size)
+                }
+            })
+        };
+        // Take alignment shift into account when specifiying length to msync
+        let align_diff = unaligned_addr - page_aligned_ptr.as_ptr() as usize;
+        let length = (end - start) + align_diff;
+        // TODO: consider MS_INVALIDATE, needed for streaming stuff
+        let ret = unsafe { libc::msync(page_aligned_ptr.as_ptr() as _, length, libc::MS_SYNC) };
+        if ret < 0 {
             let err_code = unsafe { libc::__errno_location().read() };
             Err(std::io::Error::from_raw_os_error(err_code))
         } else {

--- a/bittorrent/src/peer_connection.rs
+++ b/bittorrent/src/peer_connection.rs
@@ -392,7 +392,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection<'f_store> {
                 self.currently_downloading.push(piece);
             } else {
                 log::debug!("[Peer {}] Piece completed", self.peer_id);
-                return Some(piece.to_readable());
+                return Some(piece.into_readable());
             }
         } else {
             log::error!(

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -255,7 +255,7 @@ impl<'f_store> Piece<'f_store> {
         }
     }
 
-    pub fn to_readable(self) -> ReadablePieceFileView<'f_store> {
+    pub fn into_readable(self) -> ReadablePieceFileView<'f_store> {
         self.piece_view.into_readable()
     }
 

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use bitvec::prelude::{BitBox, Msb0};
 use lava_torrent::torrent::v1::Torrent;
 
-use crate::peer_protocol::PeerId;
+use crate::{
+    file_store::{ReadablePieceFileView, WritablePieceFileView},
+    peer_protocol::PeerId,
+};
 
 pub const SUBPIECE_SIZE: i32 = 16_384;
 
@@ -145,11 +148,14 @@ impl PieceSelector {
         self.inflight_pieces.set(index, false);
     }
 
-    // TODO: Get rid of this?
     #[inline]
     pub fn mark_inflight(&mut self, index: usize) {
-        debug_assert!(!self.completed_pieces[index]);
-        self.inflight_pieces.set(index, true);
+        // We never pick a completed piece since there might exist
+        // an ReadablePieceFileView alive for that (it also makes no sense to redownload)
+        assert!(!self.completed_pieces[index]);
+        let mut bit = self.inflight_pieces.get_mut(index).unwrap();
+        let old = bit.replace(true);
+        assert!(!old);
     }
 
     #[inline]
@@ -212,22 +218,25 @@ impl PieceSelector {
     }
 }
 
-// TODO flatten this
 #[derive(Debug)]
-pub struct Piece {
+pub struct CompletedPiece {
+    pub index: usize,
+    pub hash_matched: std::io::Result<bool>,
+}
+
+// TODO flatten this
+pub struct Piece<'f_store> {
     pub index: i32,
     // Contains only completed subpieces
     pub completed_subpieces: BitBox,
     // Contains both completed and inflight subpieces
     pub inflight_subpieces: BitBox,
     pub last_subpiece_length: i32,
-    // TODO used uninit memory here instead
-    pub memory: Vec<u8>,
+    pub piece_view: WritablePieceFileView<'f_store>,
 }
 
-impl Piece {
-    pub fn new(index: i32, lenght: u32) -> Self {
-        let memory = vec![0; lenght as usize];
+impl<'f_store> Piece<'f_store> {
+    pub fn new(index: i32, lenght: u32, piece_view: WritablePieceFileView<'f_store>) -> Self {
         let last_subpiece_length = if lenght as i32 % SUBPIECE_SIZE == 0 {
             SUBPIECE_SIZE
         } else {
@@ -242,8 +251,12 @@ impl Piece {
             completed_subpieces,
             inflight_subpieces,
             last_subpiece_length,
-            memory,
+            piece_view,
         }
+    }
+
+    pub fn to_readable(self) -> ReadablePieceFileView<'f_store> {
+        self.piece_view.into_readable()
     }
 
     pub fn on_subpiece(&mut self, index: i32, begin: i32, data: &[u8], peer_id: PeerId) {
@@ -260,8 +273,8 @@ impl Piece {
         } else {
             debug_assert_eq!(data.len() as i32, SUBPIECE_SIZE);
         }
+        self.piece_view.write_subpiece(begin as usize, data);
         self.completed_subpieces.set(subpiece_index as usize, true);
-        self.memory[begin as usize..begin as usize + data.len()].copy_from_slice(data);
     }
 
     #[inline]

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,8 @@ skip = [
     # Windows stuff shouldn't be used so I assume it's feature gated out regardles
     { name = "windows-sys", version = "*"},
     { name = "thiserror-impl" },
-    { name = "thiserror" }
+    { name = "thiserror" },
+    {name = "smallvec", version = "2.0.0-alpha.10"}
 ]
 # Going to be removed regardless
 skip-tree = [{name = "tokio-uring"}]


### PR DESCRIPTION
A complete overhaul of the File IO which gets rid of the need to heap allocate pieces during download before writing them to disk. The code now supports writing and reading subpieces directly to the mmaped files. It also supports partial file syncs and moves piece hashing and comparisons over to the rayon threadpool without the need for any `Arc`s or synchronization between threads.

The synchronization is instead happening on the event loop thread by ensuring there only exists one or more `ReadablePieceViews` for completed pieces and `WritablePieceViews` are only created for pieces that have not started. As soon as a piece is delegated out to a peer it's marked as inflight and may not be delegated again until completion (or failure).