### PR TITLE
Ensure being choked makes queued pieces available to other peers

### DIFF
--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -416,6 +416,14 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             PeerMessage::Choke => {
                 log::error!("[Peer: {}] Peer is choking us!", self.peer_id);
                 self.peer_choking = true;
+                // Interpret all sent pieces as rejected
+                if !self.fast_ext {
+                    // Append them to queue so the release_pieces logic can release the inflight
+                    // pieces as well
+                    self.queued.append(&mut self.inflight);
+                    self.inflight.clear(); 
+                }
+                self.release_pieces(torrent_state);
             }
             PeerMessage::Unchoke => {
                 self.peer_choking = false;

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -421,7 +421,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     // Append them to queue so the release_pieces logic can release the inflight
                     // pieces as well
                     self.queued.append(&mut self.inflight);
-                    self.inflight.clear(); 
+                    self.inflight.clear();
                 }
                 self.release_pieces(torrent_state);
             }

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -503,7 +503,7 @@ fn peer_choke_recv_does_not_support_fast() {
         assert_eq!(connections[key].queued.len(), 0);
         // 1 piece completed (pending hashing), one was released
         assert_eq!(torrent_state.currently_downloading.len(), 0);
-        // index = 1 is not inflight over the network but pending hashing and thus is 
+        // index = 1 is not inflight over the network but pending hashing and thus is
         // still marked inflight
         for i in 2..7 {
             // No longer inflight!

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -161,7 +161,6 @@ impl PieceSelector {
 
     #[inline]
     pub fn mark_not_inflight(&mut self, index: usize) {
-        debug_assert!(self.inflight_pieces[index]);
         self.inflight_pieces.set(index, false);
     }
 

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -143,8 +143,8 @@ impl PieceSelector {
     // TODO: Get rid of this?
     #[inline]
     pub fn mark_complete(&mut self, index: usize) {
-        debug_assert!(self.inflight_pieces[index]);
-        debug_assert!(!self.completed_pieces[index]);
+        assert!(self.inflight_pieces[index]);
+        assert!(!self.completed_pieces[index]);
         self.completed_pieces.set(index, true);
         self.inflight_pieces.set(index, false);
     }
@@ -161,6 +161,7 @@ impl PieceSelector {
 
     #[inline]
     pub fn mark_not_inflight(&mut self, index: usize) {
+        assert!(self.inflight_pieces[index]);
         self.inflight_pieces.set(index, false);
     }
 


### PR DESCRIPTION
Previously choked peers could have been allocated pieces that wouldn't be downloaded by anyone else regardless if the other unchoked peers had the piece available