### PR TITLE
Revamp timeouts

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -669,7 +669,10 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             if time.elapsed() > connection.request_timeout() {
                 // error just to make more visible
                 log::error!("TIMEOUT: {}", connection.peer_id);
-                connection.on_request_timeout(torrent_state);
+                connection.on_request_timeout(torrent_state, file_store);
+            } else if connection.snubbed {
+                // Did not timeout
+                connection.snubbed = false;
             }
         }
 

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -723,7 +723,7 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
         } {
             if let Some(next_piece) = torrent_state.piece_selector.next_piece(peer_key) {
-                let mut queue = torrent_state.request_new_piece(next_piece, file_store);
+                let mut queue = torrent_state.allocate_piece(next_piece, file_store);
                 let queue_len = queue.len();
                 peer.append_and_fill(&mut queue);
                 // Remove all subpieces from available bandwidth

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -205,10 +205,11 @@ impl<'f_store> TorrentState<'f_store> {
         // if the piece has ever been allocated it should remain in the
         // pieces vec so it's okay to unwrap here
         let piece = self.pieces[index as usize].as_mut().unwrap();
-        piece.ref_count -= 1;
-        if piece.ref_count == 0 {
+        // Will we reach 0 in the ref count?
+        if piece.ref_count == 1 {
             self.piece_selector.mark_not_allocated(index as usize);
         }
+        piece.ref_count = piece.ref_count.saturating_sub(1)
     }
 
     // TODO: Something like release in flight pieces?

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -208,11 +208,11 @@ impl<'f_store> TorrentState<'f_store> {
         index: i32,
         file_store: &'f_store FileStore,
     ) -> VecDeque<Subpiece> {
+        self.piece_selector.mark_allocated(index as usize);
         match &mut self.pieces[index as usize] {
             Some(allocated_piece) => allocated_piece.allocate_remaining_subpieces(),
             None => {
                 let length = self.piece_selector.piece_len(index);
-                self.piece_selector.mark_allocated(index as usize);
                 // SAFETY: There only exist a single piece per index in the torrent_state
                 // piece vector which guarantees that there can never be two concurrent writable
                 // piece views for the same index

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -123,6 +123,7 @@ impl<'f_store> TorrentState<'f_store> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn num_allocated(&self) -> usize {
         self.pieces
             .iter()

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -463,6 +463,8 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     // pieces as well
                     self.queued.append(&mut self.inflight);
                     self.inflight.clear();
+                    // TODO: test this
+                    self.last_received_subpiece = None;
                 }
                 self.release_all_pieces(torrent_state);
             }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -156,6 +156,7 @@ pub struct PeerConnection {
     // requests
     pub last_received_subpiece: Option<Instant>,
     pub slow_start: bool,
+    pub snubbed: bool,
     // The averge time between pieces being received
     pub moving_rtt: MovingRttAverage,
     pub throughput: u64,
@@ -190,6 +191,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             target_inflight: 4,
             last_seen: Instant::now(),
             slow_start: true,
+            snubbed: false,
             moving_rtt: Default::default(),
             pending_disconnect: None,
             throughput: 0,
@@ -236,13 +238,13 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         });
     }
 
-    fn reject_request(&mut self, subpiece: Subpiece, ordered: bool) {
+    fn reject_request(&mut self, index: i32, begin: i32, length: i32, ordered: bool) {
         // TODO: Disconnect on too many rejected pieces
         self.outgoing_msgs_buffer.push(OutgoingMsg {
             message: PeerMessage::RejectRequest {
-                index: subpiece.index,
-                begin: subpiece.offset,
-                length: subpiece.size,
+                index,
+                begin,
+                length,
             },
             ordered,
         });
@@ -289,7 +291,11 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     pub fn update_target_inflight(&mut self, target_inflight: usize) {
-        self.target_inflight = target_inflight.clamp(0, 500);
+        if self.snubbed {
+            self.target_inflight = 1;
+            return;
+        }
+        self.target_inflight = target_inflight.clamp(0, 600);
         self.target_inflight = self.target_inflight.max(1);
     }
 
@@ -353,6 +359,9 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         if self.peer_choking {
             return 0;
         }
+        if self.snubbed {
+            return 1;
+        }
         // This will work even if we are in a slow start since
         // the window will continue to increase until a timeout is hit
         // TODO: Should we really return 0 here?
@@ -404,36 +413,57 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         histogram.record(self.moving_rtt.mean());
     }
 
-    pub fn on_request_timeout(&mut self, torrent_state: &mut TorrentState) {
-        let Some(subpiece) = self.inflight.pop_back() else {
-            // Probably caused by the request being rejected or the timeout happen because
-            // we had not requested anything more
-            log::warn!(
-                "[PeerId: {}] Piece timed out but not found in inflight queue",
-                self.peer_id
-            );
-            // Don't timeout again
-            self.last_received_subpiece = None;
-            return;
-        };
-        log::warn!(
-            "[PeerId {}]: Subpiece timed out: {}, {}",
-            self.peer_id,
-            subpiece.index,
-            subpiece.offset
+    pub fn on_request_timeout(
+        &mut self,
+        torrent_state: &mut TorrentState<'f_store>,
+        file_store: &'f_store FileStore,
+    ) {
+        if !self.snubbed {
+            self.snubbed = true;
+            self.slow_start = false;
+        }
+        for subpiece in self.inflight.iter_mut().rev() {
+            if !subpiece.timed_out {
+                subpiece.timed_out = true;
+                log::warn!(
+                    "[PeerId {}]: Subpiece timed out: {}, {}",
+                    self.peer_id,
+                    subpiece.index,
+                    subpiece.offset
+                );
+                subpiece.timed_out = true;
+                // Request a new different piece and do it before clearing
+                // the queue so the same piece isn't picked again
+                let maybe_new_piece = torrent_state.piece_selector.next_piece(self.conn_id);
+                // Ensure this piece specifically is deallocated
+                // TODO: This can be improved probably
+                torrent_state.deallocate_piece(subpiece.index);
+                self.release_all_pieces(torrent_state);
+                // Make it possible to request one more piece if this
+                // is the final inflight piece
+                self.target_inflight = 2;
+                if let Some(new_piece) = maybe_new_piece {
+                    let mut subpieces = torrent_state.allocate_piece(new_piece, file_store);
+                    self.append_and_fill(&mut subpieces);
+                }
+                // Update to actual target
+                self.target_inflight = 1;
+                return;
+            }
+        }
+        // Probably caused by the request being rejected or the timeout happen because
+        // we had not requested anything more, shouldn't happen afaik
+        log::error!(
+            "[PeerId: {}] Piece timed out but not found in inflight queue",
+            self.peer_id
         );
-        self.slow_start = false;
-        self.release_all_pieces(torrent_state);
-        // TODO: time out recovery
-        self.target_inflight = 1;
+        // Don't timeout again at least
+        self.last_received_subpiece = None;
     }
 
     #[inline]
-    fn is_valid_piece_req(&self, subpiece: Subpiece, num_pieces: i32) -> bool {
-        subpiece.index >= 0
-            && subpiece.index <= num_pieces
-            && subpiece.offset % SUBPIECE_SIZE == 0
-            && subpiece.size <= SUBPIECE_SIZE
+    fn is_valid_piece_req(&self, index: i32, begin: i32, length: i32, num_pieces: i32) -> bool {
+        index >= 0 && index <= num_pieces && begin % SUBPIECE_SIZE == 0 && length <= SUBPIECE_SIZE
     }
 
     #[inline]
@@ -689,14 +719,14 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 begin,
                 length,
             } => {
-                let subpiece = Subpiece {
-                    index,
-                    offset: begin,
-                    size: length,
-                };
                 // returns if it was accepted or not
                 let mut handle_req = || {
-                    if !self.is_valid_piece_req(subpiece, torrent_state.num_pieces() as i32) {
+                    if !self.is_valid_piece_req(
+                        index,
+                        begin,
+                        length,
+                        torrent_state.num_pieces() as i32,
+                    ) {
                         log::warn!(
                             "[Peer: {}] Piece request ignored/rejected, invalid request",
                             self.peer_id
@@ -713,15 +743,12 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                         // We are either not choking or the piece is part of the fast set and they
                         // support the fast ext
                         if !self.is_choking
-                            || (self.accept_fast_pieces.contains(&subpiece.index) && self.fast_ext)
+                            || (self.accept_fast_pieces.contains(&index) && self.fast_ext)
                         {
-                            if !torrent_state
-                                .piece_selector
-                                .has_completed(subpiece.index as usize)
-                            {
+                            if !torrent_state.piece_selector.has_completed(index as usize) {
                                 return None;
                             }
-                            assert!(torrent_state.pieces[subpiece.index as usize].is_none());
+                            assert!(torrent_state.pieces[index as usize].is_none());
                             // TODO: cache this
                             // SAFETY: we've check that this is completed and the writable piece is gone
                             // from the piece vector in that case no other writers should exist for the piece
@@ -731,10 +758,8 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                                 return None;
                             };
                             // TODO: consider using maybe uninit
-                            let mut subpiece_data =
-                                vec![0; subpiece.size as usize].into_boxed_slice();
-                            readable_piece_view
-                                .read_subpiece(subpiece.offset as usize, &mut subpiece_data);
+                            let mut subpiece_data = vec![0; length as usize].into_boxed_slice();
+                            readable_piece_view.read_subpiece(begin as usize, &mut subpiece_data);
                             Some(subpiece_data)
                         } else {
                             log::warn!(
@@ -746,9 +771,9 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     }
                 };
                 if let Some(piece_data) = handle_req() {
-                    self.send_piece(subpiece.index, subpiece.offset, piece_data.into(), false);
+                    self.send_piece(index, begin, piece_data.into(), false);
                 } else if self.fast_ext {
-                    self.reject_request(subpiece, false);
+                    self.reject_request(index, begin, length, false);
                 }
             }
             PeerMessage::RejectRequest {
@@ -762,23 +787,22 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     ));
                     return;
                 }
-                let subpiece = Subpiece {
-                    index,
-                    offset: begin,
-                    size: length,
-                };
-                if !self.is_valid_piece_req(subpiece, torrent_state.num_pieces() as i32) {
+                if !self.is_valid_piece_req(index, begin, length, torrent_state.num_pieces() as i32)
+                {
                     log::warn!(
                         "[Peer: {}] Piece Reject request ignored, invalid request",
                         self.peer_id
                     );
                 }
-                if let Some(i) = self.inflight.iter().position(|q_sub| *q_sub == subpiece) {
+                if let Some(i) = self.inflight.iter().position(|q_sub| {
+                    q_sub.index == index && q_sub.offset == begin && q_sub.size == length
+                }) {
                     log::warn!(
                         "[PeerId {}]: Subpiece request rejected: {index}, {begin}",
                         self.peer_id,
                     );
                     self.inflight.remove(i).unwrap();
+                    torrent_state.deallocate_piece(index);
                 } else {
                     log::error!(
                         "[PeerId {}]: Subpiece not inflight rejected: {index}, {begin}",
@@ -819,6 +843,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                         index,
                         offset: begin,
                         size: length,
+                        timed_out: false,
                     };
                     if !self
                         .outgoing_msgs_buffer
@@ -844,7 +869,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     {
                         // We've not already queued up a response
                         // so reject the request
-                        self.reject_request(subpiece, false);
+                        self.reject_request(subpiece.index, subpiece.offset, subpiece.size, false);
                     }
                 }
             }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -295,7 +295,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             self.target_inflight = 1;
             return;
         }
-        self.target_inflight = target_inflight.clamp(0, 600);
+        self.target_inflight = target_inflight.clamp(0, 400);
         self.target_inflight = self.target_inflight.max(1);
     }
 

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -1223,7 +1223,12 @@ fn reject_request_requests_new() {
         }));
         // New piece started
         assert_eq!(torrent_state.num_allocated(), 2);
-        assert_eq!(a.inflight.len(), 3);
+        // Last piece only have one subpiece
+        if torrent_state.pieces[8].is_some() {
+            assert_eq!(a.inflight.len(), 2);
+        } else {
+            assert_eq!(a.inflight.len(), 3);
+        }
     });
 }
 

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -1128,7 +1128,9 @@ fn handles_duplicate_piece_recv() {
         );
         assert!(connections[key].last_seen.elapsed() < Duration::from_millis(1));
         // Timestamps for last_received_subpiece are not updated
-        assert!(connections[key].last_received_subpiece.unwrap().elapsed() > Duration::from_millis(100));
+        assert!(
+            connections[key].last_received_subpiece.unwrap().elapsed() > Duration::from_millis(100)
+        );
         assert_eq!(connections[key].target_inflight, prev_target_infligt + 1);
         assert_eq!(connections[key].inflight.len(), 1);
         connections[key].handle_message(

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -77,7 +77,7 @@ impl PieceSelector {
 
         if available_pieces.not_any() {
             log::warn!(
-                "There are no available pieces, inflight_pieces: {}",
+                "There are no available pieces, allocated_pieces: {}",
                 self.allocated_pieces.count_ones()
             );
             return None;
@@ -156,7 +156,6 @@ impl PieceSelector {
 
     #[inline]
     pub fn mark_complete(&mut self, index: usize) {
-        assert!(self.allocated_pieces[index]);
         assert!(!self.completed_pieces[index]);
         self.completed_pieces.set(index, true);
         self.allocated_pieces.set(index, false);

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -25,6 +25,7 @@ pub struct Subpiece {
     pub index: i32,
     pub offset: i32,
     pub size: i32,
+    pub timed_out: bool,
 }
 
 pub struct PieceSelector {
@@ -280,6 +281,7 @@ impl<'f_store> Piece<'f_store> {
                 index: self.index,
                 offset: SUBPIECE_SIZE * subpiece_index as i32,
                 size: SUBPIECE_SIZE,
+                timed_out: false,
             });
             last_is_last_index = subpiece_index == last_subpiece_index;
         }

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -30,8 +30,7 @@ pub struct Subpiece {
 pub struct PieceSelector {
     //    strategy: T,
     completed_pieces: BitBox<usize, Msb0>,
-    // TODO: rename to assinged pieces instead
-    inflight_pieces: BitBox<usize, Msb0>,
+    allocated_pieces: BitBox<usize, Msb0>,
     // These are all pieces the peer have that we have yet to complete
     // it should be kept up to date as the torrent is downloaded, completed
     // pieces are "turned off" and Have messages only set a bit if we do not already
@@ -51,7 +50,7 @@ impl PieceSelector {
 
         Self {
             completed_pieces,
-            inflight_pieces,
+            allocated_pieces: inflight_pieces,
             last_piece_length: last_piece_length as u32,
             piece_length: piece_length as u32,
             interesting_peer_pieces: Default::default(),
@@ -60,7 +59,7 @@ impl PieceSelector {
 
     fn new_available_pieces(&self, mut field: BitBox<usize, Msb0>) -> BitBox<usize, Msb0> {
         let mut tmp = self.completed_pieces.clone();
-        tmp |= &self.inflight_pieces;
+        tmp |= &self.allocated_pieces;
         field &= !tmp;
         field
     }
@@ -78,7 +77,7 @@ impl PieceSelector {
         if available_pieces.not_any() {
             log::warn!(
                 "There are no available pieces, inflight_pieces: {}",
-                self.inflight_pieces.count_ones()
+                self.allocated_pieces.count_ones()
             );
             return None;
         }
@@ -156,10 +155,10 @@ impl PieceSelector {
 
     #[inline]
     pub fn mark_complete(&mut self, index: usize) {
-        assert!(self.inflight_pieces[index]);
+        assert!(self.allocated_pieces[index]);
         assert!(!self.completed_pieces[index]);
         self.completed_pieces.set(index, true);
-        self.inflight_pieces.set(index, false);
+        self.allocated_pieces.set(index, false);
         // The piece is no longer interesting if we've completed it
         for interesting_pieces in self.interesting_peer_pieces.values_mut() {
             interesting_pieces.set(index, false);
@@ -167,19 +166,19 @@ impl PieceSelector {
     }
 
     #[inline]
-    pub fn mark_inflight(&mut self, index: usize) {
+    pub fn mark_allocated(&mut self, index: usize) {
         // We never pick a completed piece since there might exist
         // an ReadablePieceFileView alive for that (it also makes no sense to redownload)
         assert!(!self.completed_pieces[index]);
-        let mut bit = self.inflight_pieces.get_mut(index).unwrap();
+        let mut bit = self.allocated_pieces.get_mut(index).unwrap();
         let old = bit.replace(true);
         assert!(!old);
     }
 
     #[inline]
-    pub fn mark_not_inflight(&mut self, index: usize) {
-        assert!(self.inflight_pieces[index]);
-        self.inflight_pieces.set(index, false);
+    pub fn mark_not_allocated(&mut self, index: usize) {
+        assert!(self.allocated_pieces[index]);
+        self.allocated_pieces.set(index, false);
     }
 
     #[inline]
@@ -198,8 +197,8 @@ impl PieceSelector {
     }
 
     #[inline]
-    pub fn is_inflight(&self, index: usize) -> bool {
-        self.inflight_pieces[index]
+    pub fn is_allocated(&self, index: usize) -> bool {
+        self.allocated_pieces[index]
     }
 
     #[inline]
@@ -214,7 +213,7 @@ impl PieceSelector {
 
     #[inline]
     pub fn total_inflight(&self) -> usize {
-        self.inflight_pieces.count_ones()
+        self.allocated_pieces.count_ones()
     }
 
     #[inline]

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -301,6 +301,9 @@ impl<'f_store> Piece<'f_store> {
         // This subpice is part of the currently downloading piece
         debug_assert_eq!(self.index, index);
         let subpiece_index = begin / SUBPIECE_SIZE;
+        if self.completed_subpieces[subpiece_index as usize] {
+            return;
+        }
         log::trace!("Subpiece index received: {subpiece_index}",);
         let last_subpiece = subpiece_index == self.last_subpiece_index();
         if last_subpiece {


### PR DESCRIPTION
- Conceptually change currently_downloading to pieces where Some() indicates the piece have been started
- Only remove inflight when explicitly rejected when fast_ext is enabled (dealt in Choke for non fast_ext)
- Introduce concept of snubbed peers
- Move over to allocated/deallocated pieces instead of inflight pieces which also better fits the safety invariants of the file store
- Tweak the target inflight clamp (we can now recover much better when this is too large as well)