### PR TITLE
Fix UB in connection code

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
     builder.install().unwrap();
     // TODO Should start dht first
     let torrent_info =
-        lava_torrent::torrent::v1::Torrent::read_from_file("debian.torrent").unwrap();
+        lava_torrent::torrent::v1::Torrent::read_from_file("linux-mint.torrent").unwrap();
     let (tx, rc) = std::sync::mpsc::channel();
 
     let info_hash = torrent_info.info_hash_bytes();


### PR DESCRIPTION
I realized I've had the most basic UB in my connection code since I provided the kernel a stack allocated pointer instead of the pointer to the socket address stored in the event lol. Realized this after refactoring the with unrelated changes and I started to see EAFNOSUPPORT when testing locally against my transmission container. Ooops!

Doesn't seem like the LinkedTimeout requires the Timespec to live as long  but it doesn't hurt to make it const