### PR TITLE
Fix bitfield bugs and return to u8 store backing

### DIFF
--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -637,7 +637,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 }
                 let num_pieces = torrent_state.num_pieces();
                 log::info!("[Peer: {}] Have all received", self.peer_id);
-                let bitfield = bitvec::bitvec!(usize, bitvec::order::Msb0; 1; num_pieces);
+                let bitfield = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; num_pieces);
                 torrent_state
                     .piece_selector
                     .peer_bitfield(self.conn_id, bitfield.into_boxed_bitslice());
@@ -661,7 +661,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 }
                 let num_pieces = torrent_state.num_pieces();
                 log::info!("[Peer: {}] Have None received", self.peer_id);
-                let bitfield = bitvec::bitvec!(usize, bitvec::order::Msb0; 0; num_pieces);
+                let bitfield = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
                 self.not_interested(false);
                 torrent_state
                     .piece_selector

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -672,7 +672,7 @@ fn bitfield_recv() {
             let mut b = generate_peer(true, 0);
             assert!(b.pending_disconnect.is_none());
             let invalid_field =
-                bitvec::bitvec!(usize, bitvec::order::Msb0; 1; torrent_state.num_pieces() - 1);
+                bitvec::bitvec!(u8, bitvec::order::Msb0; 1; torrent_state.num_pieces() - 1);
             b.handle_message(
                 PeerMessage::Bitfield(invalid_field),
                 &mut torrent_state,
@@ -686,7 +686,7 @@ fn bitfield_recv() {
         let mut a = generate_peer(true, 0);
         assert!(!a.is_interesting);
         assert!(!torrent_state.piece_selector.bitfield_received(a.conn_id));
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 1; torrent_state.num_pieces());
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; torrent_state.num_pieces());
         field.set(2, false);
         field.set(4, false);
         a.handle_message(
@@ -725,7 +725,7 @@ fn bitfield_recv() {
         assert!(!b.is_interesting);
         assert!(!torrent_state.piece_selector.bitfield_received(b.conn_id));
         let num_pieces = torrent_state.num_pieces();
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 1; num_pieces);
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; num_pieces);
         field.set(2, false);
         field.set(4, false);
         b.handle_message(
@@ -743,7 +743,7 @@ fn bitfield_recv() {
         assert!(!c.is_interesting);
         assert!(!torrent_state.piece_selector.bitfield_received(c.conn_id));
         let num_pieces = torrent_state.num_pieces();
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 1; num_pieces);
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; num_pieces);
         field.set(2, false);
         c.handle_message(
             PeerMessage::Bitfield(field),
@@ -775,7 +775,7 @@ fn interest_is_updated_when_recv_piece() {
                 .bitfield_received(connections[key].conn_id)
         );
         let num_pieces = torrent_state.num_pieces();
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 0; num_pieces);
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(2, true);
         field.set(4, true);
         connections[key].handle_message(
@@ -869,7 +869,7 @@ fn send_have_to_peers_when_piece_completes() {
         connections.insert(c);
 
         let num_pieces = torrent_state.num_pieces();
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 0; num_pieces);
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(2, true);
         connections[key_a].handle_message(
             PeerMessage::Bitfield(field),
@@ -878,7 +878,7 @@ fn send_have_to_peers_when_piece_completes() {
             &torrent_info,
             scope,
         );
-        let mut field = bitvec::bitvec!(usize, bitvec::order::Msb0; 0; num_pieces);
+        let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(4, true);
         connections[key_b].handle_message(
             PeerMessage::Bitfield(field),

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -30,20 +30,20 @@ pub struct Subpiece {
 
 pub struct PieceSelector {
     //    strategy: T,
-    completed_pieces: BitBox<usize, Msb0>,
-    allocated_pieces: BitBox<usize, Msb0>,
+    completed_pieces: BitBox<u8, Msb0>,
+    allocated_pieces: BitBox<u8, Msb0>,
     // These are all pieces the peer have that we have yet to complete
     // it should be kept up to date as the torrent is downloaded, completed
     // pieces are "turned off" and Have messages only set a bit if we do not already
     // have it.
-    interesting_peer_pieces: HashMap<usize, BitBox<usize, Msb0>>,
+    interesting_peer_pieces: HashMap<usize, BitBox<u8, Msb0>>,
     last_piece_length: u32,
     piece_length: u32,
 }
 
 impl PieceSelector {
     pub fn new(torrent_info: &Torrent) -> Self {
-        let completed_pieces: BitBox<usize, Msb0> =
+        let completed_pieces: BitBox<u8, Msb0> =
             torrent_info.pieces.iter().map(|_| false).collect();
         let inflight_pieces = completed_pieces.clone();
         let piece_length = torrent_info.piece_length;
@@ -58,7 +58,7 @@ impl PieceSelector {
         }
     }
 
-    fn new_available_pieces(&self, mut field: BitBox<usize, Msb0>) -> BitBox<usize, Msb0> {
+    fn new_available_pieces(&self, mut field: BitBox<u8, Msb0>) -> BitBox<u8, Msb0> {
         let mut tmp = self.completed_pieces.clone();
         tmp |= &self.allocated_pieces;
         field &= !tmp;
@@ -121,11 +121,7 @@ impl PieceSelector {
     }
 
     // Updates the interesting peer pieces and returns if the peer has any interesting pieces
-    pub fn peer_bitfield(
-        &mut self,
-        connection_id: usize,
-        peer_pieces: BitBox<usize, Msb0>,
-    ) -> bool {
+    pub fn peer_bitfield(&mut self, connection_id: usize, peer_pieces: BitBox<u8, Msb0>) -> bool {
         let not_completed = !self.completed_pieces.clone();
         let interesting_pieces = peer_pieces & not_completed;
         let is_interesting = interesting_pieces.any();
@@ -141,7 +137,7 @@ impl PieceSelector {
         entry
             .and_modify(|pieces| pieces.set(piece_index, is_interesting))
             .or_insert_with(|| {
-                let mut all_pieces: BitBox<usize, Msb0> =
+                let mut all_pieces: BitBox<u8, Msb0> =
                     (0..self.completed_pieces.len()).map(|_| false).collect();
                 all_pieces.set(piece_index, is_interesting);
                 all_pieces
@@ -150,7 +146,7 @@ impl PieceSelector {
     }
 
     // All interesting peer pieces if a bitfield has been received
-    pub fn interesting_peer_pieces(&self, connection_id: usize) -> Option<&BitBox<usize, Msb0>> {
+    pub fn interesting_peer_pieces(&self, connection_id: usize) -> Option<&BitBox<u8, Msb0>> {
         self.interesting_peer_pieces.get(&connection_id)
     }
 
@@ -187,7 +183,7 @@ impl PieceSelector {
     }
 
     #[inline]
-    pub fn completed_clone(&self) -> BitBox<usize, Msb0> {
+    pub fn completed_clone(&self) -> BitBox<u8, Msb0> {
         self.completed_pieces.clone()
     }
 


### PR DESCRIPTION
Previous implementation contained bugs both with panics when parsing incoming bitfields that weren't a size multiple of sizeof(usize) as well as the memory ordering. 

Not worth to keep the complexity for such unclear gains with using usize as a backing storage so moving back to u8 and simplifying