### PR TITLE
Implement max connections cap + panic fixes

### DIFF
--- a/bittorrent/src/buf_ring.rs
+++ b/bittorrent/src/buf_ring.rs
@@ -107,35 +107,26 @@ impl BufferRing {
             match e.raw_os_error() {
                 Some(libc::EINVAL) => {
                     // using buf_ring requires kernel 5.19 or greater.
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "buf_ring.register returned {}, most likely indicating this kernel is not 5.19+",
-                            e
-                        ),
-                    ));
+                    return Err(io::Error::other(format!(
+                        "buf_ring.register returned {}, most likely indicating this kernel is not 5.19+",
+                        e
+                    )));
                 }
                 Some(libc::EEXIST) => {
                     // Registering a duplicate bgid is not allowed. There is an `unregister`
                     // operations that can remove the first, but care must be taken that there
                     // are no outstanding operations that will still return a buffer from that
                     // one.
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "buf_ring.register returned `{}`, indicating the attempted buffer group id {} was already registered",
-                            e, self.bgid
-                        ),
-                    ));
+                    return Err(io::Error::other(format!(
+                        "buf_ring.register returned `{}`, indicating the attempted buffer group id {} was already registered",
+                        e, self.bgid
+                    )));
                 }
                 _ => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "buf_ring.register returned `{}` for group id {}",
-                            e, self.bgid
-                        ),
-                    ));
+                    return Err(io::Error::other(format!(
+                        "buf_ring.register returned `{}` for group id {}",
+                        e, self.bgid
+                    )));
                 }
             }
         };

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -133,10 +133,10 @@ fn event_error_handler<Q: SubmissionQueue>(
             }
             Ok(())
         }
-        libc::ECONNREFUSED => {
+        libc::ECONNREFUSED | libc::EHOSTUNREACH => {
             // Failling to connect due to this is not really an error due to
             // the likelyhood of being stale info in the DHT
-            log::debug!("Connection refused");
+            log::debug!("Connection failed");
             Ok(())
         }
         libc::ECANCELED => {

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -202,7 +202,7 @@ impl<'f_store> TorrentState<'f_store> {
     }
 
     fn deallocate_piece(&mut self, index: i32) {
-        // The piece might have been mid hashing when a timeout is received 
+        // The piece might have been mid hashing when a timeout is received
         // (two separate peer) which causes to be completed whilst another peer
         // tried to download it. It's fine (TODO: confirm)
         if let Some(piece) = self.pieces[index as usize].as_mut() {

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -202,14 +202,16 @@ impl<'f_store> TorrentState<'f_store> {
     }
 
     fn deallocate_piece(&mut self, index: i32) {
-        // if the piece has ever been allocated it should remain in the
-        // pieces vec so it's okay to unwrap here
-        let piece = self.pieces[index as usize].as_mut().unwrap();
-        // Will we reach 0 in the ref count?
-        if piece.ref_count == 1 {
-            self.piece_selector.mark_not_allocated(index as usize);
+        // The piece might have been mid hashing when a timeout is received 
+        // (two separate peer) which causes to be completed whilst another peer
+        // tried to download it. It's fine (TODO: confirm)
+        if let Some(piece) = self.pieces[index as usize].as_mut() {
+            // Will we reach 0 in the ref count?
+            if piece.ref_count == 1 {
+                self.piece_selector.mark_not_allocated(index as usize);
+            }
+            piece.ref_count = piece.ref_count.saturating_sub(1)
         }
-        piece.ref_count = piece.ref_count.saturating_sub(1)
     }
 
     // TODO: Something like release in flight pieces?

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -106,9 +106,7 @@ impl<'f_store> TorrentState<'f_store> {
     pub fn new(torrent: &lava_torrent::torrent::v1::Torrent) -> Self {
         let info_hash = torrent.info_hash_bytes().try_into().unwrap();
         let mut pieces = Vec::with_capacity(torrent.pieces.len());
-        // Allow the vec to use piece indicies directly without - 1
-        // everywhere
-        for _ in 0..=torrent.pieces.len() {
+        for _ in 0..torrent.pieces.len() {
             pieces.push(None);
         }
         let (tx, rc) = std::sync::mpsc::channel();
@@ -134,7 +132,7 @@ impl<'f_store> TorrentState<'f_store> {
 
     #[inline]
     pub fn num_pieces(&self) -> usize {
-        self.pieces.len() - 1
+        self.pieces.len()
     }
 
     // TODO: Put this in the event loop directly instead when that is easier to test

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -827,10 +827,11 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                         }
                         let mut subpieces = torrent_state.allocate_piece(new_index, file_store);
                         self.append_and_fill(&mut subpieces);
-                    } else if self.inflight.is_empty() {
-                        // TODO: Test this
-                        self.last_received_subpiece = None;
                     }
+                }
+                if self.inflight.is_empty() {
+                    // TODO: Test this
+                    self.last_received_subpiece = None;
                 }
                 if defer_deallocation {
                     torrent_state.deallocate_piece(index);

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -274,6 +274,7 @@ fn slow_start() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -316,6 +317,7 @@ fn slow_start() {
         tick(
             &Duration::from_millis(1500),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -353,6 +355,7 @@ fn slow_start() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -389,6 +392,7 @@ fn slow_start() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -439,6 +443,7 @@ fn desired_queue_size() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -449,6 +454,7 @@ fn desired_queue_size() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -506,6 +512,7 @@ fn peer_choke_recv_supports_fast() {
         tick(
             &Duration::from_millis(650),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -579,6 +586,7 @@ fn peer_choke_recv_does_not_support_fast() {
         tick(
             &Duration::from_millis(650),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -1309,6 +1317,7 @@ fn snubbed_peer() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );
@@ -1334,6 +1343,7 @@ fn snubbed_peer() {
         tick(
             &Duration::from_secs(1),
             &mut connections,
+            &Default::default(),
             &file_store,
             &mut torrent_state,
         );

--- a/bittorrent/tests/basic.rs
+++ b/bittorrent/tests/basic.rs
@@ -19,8 +19,10 @@ fn basic_seeded_download() {
     let download_time = Instant::now();
     let (tx, rc) = std::sync::mpsc::channel();
 
-    tx.send(Command::ConnectToPeer("127.0.0.1:51413".parse().unwrap()))
-        .unwrap();
+    tx.send(Command::ConnectToPeers(vec![
+        "127.0.0.1:51413".parse().unwrap(),
+    ]))
+    .unwrap();
 
     // Spawn a thread to send Stop command after a timeout
     let tx_clone = tx.clone();

--- a/dashboards.json
+++ b/dashboards.json
@@ -86,6 +86,272 @@
         "x": 0,
         "y": 0
       },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "peer_handshake_attempt",
+          "legendFormat": "attempts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "peer_handshake_timeout",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "peer_handshake_success",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "success",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Handshake success ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "eek7csbvj1l34d"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "{__name__=\"peer_connect_attempts\", instance=\"host.containers.internal:9000\", job=\"vortex\"}"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "peer_connect_attempts",
+          "legendFormat": "connect_attempts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "peer_connect_timeout",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "timeouts",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "peer_connect_success",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "success",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "expr": "",
+          "hide": false,
+          "instant": false,
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Connection success ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "eek7csbvj1l34d"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 5,
       "options": {
         "legend": {
@@ -145,243 +411,6 @@
         }
       ],
       "title": "Pieces",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "eek7csbvj1l34d"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "aebvmdvnsdatcb"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "peer_throughput_bytes",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": true,
-          "legendFormat": "{{peer_id}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Throughput",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "eek7csbvj1l34d"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "custom.lineStyle",
-                "value": {
-                  "dash": [
-                    10,
-                    10
-                  ],
-                  "fill": "dash"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.6.1",
-      "targets": [
-        {
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "peer_inflight",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "inflight {{peer_id}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "eek7csbvj1l34d"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "peer_target_inflight",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "target inflight {{peer_id}}",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        }
-      ],
-      "title": "Peer inflight",
       "type": "timeseries"
     },
     {
@@ -508,6 +537,9 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -537,7 +569,26 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -545,7 +596,7 @@
         "x": 0,
         "y": 16
       },
-      "id": 2,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -564,16 +615,33 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "peer_queued",
+          "expr": "peer_inflight",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "inflight {{peer_id}}",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "peer_target_inflight",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "target inflight {{peer_id}}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "title": "Queue size",
+      "title": "Peer inflight",
       "type": "timeseries"
     },
     {
@@ -703,9 +771,220 @@
           "range": true,
           "refId": "B",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "num_pending_connections",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "num_pending_connections",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "eek7csbvj1l34d"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "peer_queued",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Queue size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "eek7csbvj1l34d"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "aebvmdvnsdatcb"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(job) (peer_throughput_bytes)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": true,
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Throughput",
       "type": "timeseries"
     }
   ],
@@ -717,12 +996,12 @@
     "list": []
   },
   "time": {
-    "from": "2025-05-01T07:57:49.319Z",
-    "to": "2025-05-01T07:58:09.464Z"
+    "from": "now-5m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Throughput",
   "uid": "eebvxemmfqh34d",
-  "version": 20
+  "version": 28
 }


### PR DESCRIPTION
This enforces a max connection cap which also makes the peer ramp up significantly slower since we now wait on pending connections to complete either as failures or successes before attempting any more connections. This can be improved in the future but I felt it was best to cap this off to begin with to prevent overload of peers.

This also moves more of the responsibility of of which peers should be attempted to connect with over to the bittorrent library instead of the client. This might change in the future

It also updates the dashboard and implements some misc fixes related to panics 