### PR TITLE
Improve connection shutdown flow and tweak max target inflight

### DIFF
--- a/bittorrent/src/io_utils.rs
+++ b/bittorrent/src/io_utils.rs
@@ -143,7 +143,7 @@ pub fn write_to_connection<Q: SubmissionQueue>(
     sq.push(write_op);
 }
 
-// Cancelles all operations on the socket and initiates graceful shutdown
+// Cancels all operations on the socket and initiates graceful shutdown
 pub fn stop_connection<Q: SubmissionQueue>(
     sq: &mut BackloggedSubmissionQueue<Q>,
     conn_id: usize,

--- a/bittorrent/src/io_utils.rs
+++ b/bittorrent/src/io_utils.rs
@@ -1,11 +1,19 @@
-use std::{collections::VecDeque, io, os::fd::RawFd, ptr::null_mut};
+use std::{
+    collections::VecDeque,
+    io,
+    os::fd::{IntoRawFd, RawFd},
+    ptr::null_mut,
+};
 
 use io_uring::{
-    Submitter, opcode,
+    Submitter,
+    opcode::{self},
     squeue::PushError,
     types::{self, CancelBuilder, Timespec},
 };
+use libc::SHUT_WR;
 use slab::Slab;
+use socket2::Socket;
 
 use crate::{buf_ring::Bgid, event_loop::EventType};
 
@@ -135,14 +143,14 @@ pub fn write_to_connection<Q: SubmissionQueue>(
     sq.push(write_op);
 }
 
-// Cancelles all operations on the socket
+// Cancelles all operations on the socket and initiates graceful shutdown
 pub fn stop_connection<Q: SubmissionQueue>(
     sq: &mut BackloggedSubmissionQueue<Q>,
     conn_id: usize,
     fd: RawFd,
     events: &mut Slab<EventType>,
 ) {
-    let event = events.insert(EventType::ConnectionStopped {
+    let event = events.insert(EventType::Cancel {
         connection_idx: conn_id,
     });
     let user_data = UserData::new(event, None);
@@ -150,6 +158,27 @@ pub fn stop_connection<Q: SubmissionQueue>(
         .build()
         .user_data(user_data.as_u64());
     sq.push(cancel_op);
+    let event = events.insert(EventType::Shutdown {
+        connection_idx: conn_id,
+    });
+    let user_data = UserData::new(event, None);
+    let shutdown_op = opcode::Shutdown::new(types::Fd(fd), SHUT_WR)
+        .build()
+        .user_data(user_data.as_u64());
+    sq.push(shutdown_op);
+}
+
+pub fn close_socket<Q: SubmissionQueue>(
+    sq: &mut BackloggedSubmissionQueue<Q>,
+    socket: Socket,
+    events: &mut Slab<EventType>,
+) {
+    let event = events.insert(EventType::Close);
+    let user_data = UserData::new(event, None);
+    let close_op = opcode::Close::new(types::Fd(socket.into_raw_fd()))
+        .build()
+        .user_data(user_data.as_u64());
+    sq.push(close_op);
 }
 
 pub fn recv<Q: SubmissionQueue>(

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -293,7 +293,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             self.target_inflight = 1;
             return;
         }
-        self.target_inflight = target_inflight.clamp(0, 400);
+        self.target_inflight = target_inflight.clamp(0, 200);
         self.target_inflight = self.target_inflight.max(1);
     }
 

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -487,7 +487,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         self.last_seen = Instant::now();
         match peer_message {
             PeerMessage::Choke => {
-                log::error!("[Peer: {}] Peer is choking us!", self.peer_id);
+                log::debug!("[Peer: {}] Peer is choking us!", self.peer_id);
                 self.peer_choking = true;
                 // Interpret all sent pieces as rejected
                 if !self.fast_ext {

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -117,12 +117,8 @@ pub struct OutgoingMsg {
 
 #[derive(Error, Debug)]
 pub enum DisconnectReason {
-    #[error("Peer closed the connection")]
-    ClosedConnection,
     #[error("Peer was idle for too long")]
     Idle,
-    #[error("Peer reset the underlying connection")]
-    TcpReset,
     #[error("Protocol error {0}")]
     ProtocolError(&'static str),
     #[error("Invalid message received")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ use vortex_bittorrent::{Command, Torrent, generate_peer_id};
 
 fn main() {
     let mut log_builder = env_logger::builder();
-    log_builder.filter_level(log::LevelFilter::Info).init();
+    log_builder.filter_level(log::LevelFilter::Error).init();
 
     let builder = PrometheusBuilder::new();
     builder.install().unwrap();


### PR DESCRIPTION
- Closes sockets via io_uring instead of relying on socket's Drop implementation which makes it more explicit
- Shutdown sockets via io_uring instead of simply cancelling all requests
- Shutdown via SHUT_WR to allow for a graceful shutdown
- Ensure events are always cleaned up (previously `ConnectionStopped` was never removed)
- Tweak max target inflight to match libtorrent