### PR TITLE
Fix panic with last_received_subpiece

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -29,6 +29,7 @@ use crate::{
     piece_selector::{self, SUBPIECE_SIZE},
 };
 
+pub const MAX_QUEUE_SIZE: usize = 200;
 const HANDSHAKE_TIMEOUT_SECS: u64 = 7;
 const MAX_CONNECTIONS: usize = 100;
 const CONNECT_TIMEOUT: Timespec = Timespec::new().sec(10);

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -11,6 +11,7 @@ use socket2::Socket;
 
 use crate::{
     Error, TorrentState,
+    event_loop::MAX_QUEUE_SIZE,
     file_store::FileStore,
     peer_protocol::{PeerId, PeerMessage, PeerMessageDecoder},
     piece_selector::{CompletedPiece, SUBPIECE_SIZE, Subpiece},
@@ -293,7 +294,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             self.target_inflight = 1;
             return;
         }
-        self.target_inflight = target_inflight.clamp(0, 200);
+        self.target_inflight = target_inflight.clamp(0, MAX_QUEUE_SIZE);
         self.target_inflight = self.target_inflight.max(1);
     }
 


### PR DESCRIPTION
I want to revisit the logic surrounding this in the future but this at least fixes the panic and seems to mimic timeout logic seen in other implementations. Feels like it will give a incorrect timeout value but perhaps that's expected?