### PR TITLE
Add Endgame mode to peers

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -892,7 +892,8 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             let nothing_queued = peer.queued.is_empty();
             (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
         } {
-            if let Some(next_piece) = torrent_state.piece_selector.next_piece(peer_key) {
+            if let Some((next_piece, endgame)) = torrent_state.piece_selector.next_piece(peer_key) {
+                peer.endgame = endgame;
                 let mut queue = torrent_state.allocate_piece(next_piece, file_store);
                 let queue_len = queue.len();
                 peer.append_and_fill(&mut queue);

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -892,7 +892,10 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             let nothing_queued = peer.queued.is_empty();
             (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
         } {
-            if let Some(next_piece) = torrent_state.piece_selector.next_piece(peer_key, &mut peer.endgame) {
+            if let Some(next_piece) = torrent_state
+                .piece_selector
+                .next_piece(peer_key, &mut peer.endgame)
+            {
                 let mut queue = torrent_state.allocate_piece(next_piece, peer.conn_id, file_store);
                 let queue_len = queue.len();
                 peer.append_and_fill(&mut queue);

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -892,8 +892,7 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             let nothing_queued = peer.queued.is_empty();
             (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
         } {
-            if let Some((next_piece, endgame)) = torrent_state.piece_selector.next_piece(peer_key) {
-                peer.endgame = endgame;
+            if let Some(next_piece) = torrent_state.piece_selector.next_piece(peer_key, &mut peer.endgame) {
                 let mut queue = torrent_state.allocate_piece(next_piece, peer.conn_id, file_store);
                 let queue_len = queue.len();
                 peer.append_and_fill(&mut queue);

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -894,7 +894,7 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
         } {
             if let Some((next_piece, endgame)) = torrent_state.piece_selector.next_piece(peer_key) {
                 peer.endgame = endgame;
-                let mut queue = torrent_state.allocate_piece(next_piece, file_store);
+                let mut queue = torrent_state.allocate_piece(next_piece, peer.conn_id, file_store);
                 let queue_len = queue.len();
                 peer.append_and_fill(&mut queue);
                 // Remove all subpieces from available bandwidth

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -800,8 +800,8 @@ fn report_tick_metrics(
 ) {
     let counter = metrics::counter!("pieces_completed");
     counter.absolute(torrent_state.piece_selector.total_completed() as u64);
-    let gauge = metrics::gauge!("pieces_inflight");
-    gauge.set(torrent_state.piece_selector.total_inflight() as u32);
+    let gauge = metrics::gauge!("pieces_allocated");
+    gauge.set(torrent_state.piece_selector.total_allocated() as u32);
     let gauge = metrics::gauge!("num_unchoked");
     gauge.set(torrent_state.num_unchoked);
     let gauge = metrics::gauge!("num_connections");

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -168,7 +168,8 @@ impl<'f_store> TorrentState<'f_store> {
                             }
                         }
                     } else {
-                        // only need to do that when failing hashing since
+                        // Only need to mark this as not hashing when it fails
+                        // since otherwise it will be marked as completed and this is moot
                         self.piece_selector.mark_not_hashing(completed_piece.index);
                         // TODO: disconnect, there also might be a minimal chance of a race
                         // condition here where the connection id is replaced (by disconnect +

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -160,8 +160,12 @@ impl<'f_store> TorrentState<'f_store> {
                         log::debug!("Piece {} completed!", completed_piece.index);
 
                         if self.piece_selector.completed_all() {
-                            // TODO: mark all as not interesting
                             self.is_complete = true;
+                            // We are no longer interestead in any of the
+                            // peers
+                            for (_, peer) in connections.iter_mut() {
+                                peer.not_interested(false);
+                            }
                         }
                     } else {
                         // only need to do that when failing hashing since

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -202,12 +202,11 @@ impl<'f_store> TorrentState<'f_store> {
 
     // Deallocate a piece and mark the index again if the connection is in endgame mode
     // since those are marked as not interesting to prevent repicking of pieces
-    fn deallocate_piece(&mut self, index: i32, endgame_conn_id: Option<usize>) {
-        if let Some(conn_id) = endgame_conn_id {
-            // Mark the piece as interesting again so it can be picked again
-            // if necessary
-            self.piece_selector.peer_have_piece(conn_id, index as usize);
-        }
+    fn deallocate_piece(&mut self, index: i32, endgame_conn_id: usize) {
+        // Mark the piece as interesting again so it can be picked again
+        // if necessary
+        self.piece_selector
+            .update_peer_piece_intrest(endgame_conn_id, index as usize);
         // The piece might have been mid hashing when a timeout is received
         // (two separate peer) which causes to be completed whilst another peer
         // tried to download it. It's fine (TODO: confirm)

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -146,7 +146,11 @@ impl<'f_store> TorrentState<'f_store> {
                             if let Some(bitfield) =
                                 self.piece_selector.interesting_peer_pieces(conn_id)
                             {
-                                if !bitfield.any() && peer.is_interesting {
+                                if !bitfield.any()
+                                    && peer.is_interesting
+                                    && peer.queued.is_empty()
+                                    && peer.inflight.is_empty()
+                                {
                                     // We are no longer interestead in this peer
                                     peer.not_interested(false);
                                 }

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -156,9 +156,12 @@ impl<'f_store> TorrentState<'f_store> {
                         log::debug!("Piece {} completed!", completed_piece.index);
 
                         if self.piece_selector.completed_all() {
+                            // TODO: mark all as not interesting
                             self.is_complete = true;
                         }
                     } else {
+                        // only need to do that when failing hashing since
+                        self.piece_selector.mark_not_hashing(completed_piece.index);
                         // TODO: disconnect, there also might be a minimal chance of a race
                         // condition here where the connection id is replaced (by disconnect +
                         // new connection so that the wrong peer is marked) but this should be

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -217,7 +217,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     acc
                 });
         for piece in pieces {
-            torrent_state.deallocate_piece(piece, self.endgame.then_some(self.conn_id));
+            torrent_state.deallocate_piece(piece, self.conn_id);
         }
         self.queued.clear();
     }
@@ -451,8 +451,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 // before this call since it should only be interesting if we _were_ in endgame
                 // mode or not.
                 // TODO: This can be improved probably
-                torrent_state
-                    .deallocate_piece(subpiece.index, self.endgame.then_some(self.conn_id));
+                torrent_state.deallocate_piece(subpiece.index, self.conn_id);
                 self.release_all_pieces(torrent_state);
                 // Make it possible to request one more piece if this
                 // is the final inflight piece
@@ -597,7 +596,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 let index = index as usize;
                 let is_interesting = torrent_state
                     .piece_selector
-                    .peer_have_piece(self.conn_id, index);
+                    .update_peer_piece_intrest(dbg!(self.conn_id), dbg!(index));
                 if is_interesting && !self.is_interesting {
                     self.interested(false);
                 }
@@ -834,8 +833,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                         if defer_deallocation {
                             defer_deallocation = false;
                             // Use the old endgame value
-                            torrent_state
-                                .deallocate_piece(index, self.endgame.then_some(self.conn_id));
+                            torrent_state.deallocate_piece(index, self.conn_id);
                         }
                         self.endgame = endgame;
                         let mut subpieces = torrent_state.allocate_piece(new_index, file_store);
@@ -843,7 +841,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     }
                 }
                 if defer_deallocation {
-                    torrent_state.deallocate_piece(index, self.endgame.then_some(self.conn_id));
+                    torrent_state.deallocate_piece(index, self.conn_id);
                 }
                 self.fill_request_queue();
             }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -411,8 +411,16 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
 
         let gauge = metrics::gauge!("peer.queued", "peer_id" => self.peer_id.to_string());
         gauge.set(self.queued.len() as u32);
+
+        let gauge = metrics::gauge!("peer.snubbed", "peer_id" => self.peer_id.to_string());
+        gauge.set(if self.snubbed { 1 } else { 0 } as u32);
+
+        let gauge = metrics::gauge!("peer.endgame", "peer_id" => self.peer_id.to_string());
+        gauge.set(if self.endgame { 1 } else { 0 } as u32);
+
         let gauge = metrics::gauge!("peer.inflight", "peer_id" => self.peer_id.to_string());
         gauge.set(self.inflight.len() as u32);
+
         let histogram = metrics::histogram!("rtt", "peer_id" => self.peer_id.to_string());
         histogram.record(self.moving_rtt.mean());
     }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -829,7 +829,6 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     {
                         if defer_deallocation {
                             defer_deallocation = false;
-                            // Use the old endgame value
                             torrent_state.deallocate_piece(index, self.conn_id);
                         }
                         self.endgame = endgame;

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -927,6 +927,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     .map(|completed_piece| completed_piece.into_readable())
                 {
                     log::debug!("Piece {index} download completed, sending to hash thread");
+                    torrent_state.piece_selector.mark_hashing(index as usize);
                     let complete_tx = torrent_state.completed_piece_tx.clone();
                     let conn_id = self.conn_id;
                     scope.spawn(move |_| {

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -443,6 +443,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     .piece_selector
                     .next_piece(self.conn_id, &mut self.endgame);
                 // Ensure this piece specifically is deallocated
+                // TODO: This can be improved probably
                 torrent_state.deallocate_piece(subpiece.index, self.conn_id);
                 self.release_all_pieces(torrent_state);
                 // Make it possible to request one more piece if this
@@ -609,7 +610,6 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                         .piece_selector
                         .interesting_peer_pieces(self.conn_id)
                     {
-                        // maste markera som allokerad har! eller atminstonde valj fran fast set
                         if interesting_pieces[index as usize]
                             && !torrent_state.piece_selector.is_allocated(index as usize)
                         {

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -179,7 +179,10 @@ fn have() {
             scope,
         );
         assert!(connections[key_a].outgoing_msgs_buffer.is_empty());
-        let (index, _) = torrent_state.piece_selector.next_piece(key_a).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key_a, &mut connections[key_a].endgame)
+            .unwrap();
         assert_eq!(index, 7);
         let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_store);
         connections[key_a].append_and_fill(&mut subpieces);
@@ -348,7 +351,10 @@ fn slow_start() {
             scope,
         );
 
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         assert_eq!(index, 1);
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
@@ -399,7 +405,11 @@ fn slow_start() {
             &torrent_info,
             scope,
         );
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
+        assert_eq!(index, 2);
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
@@ -445,7 +455,11 @@ fn slow_start() {
             scope,
         );
 
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
+        assert_eq!(index, 3);
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
@@ -504,7 +518,10 @@ fn desired_queue_size() {
         );
         connections[key].peer_choking = false;
         connections[key].slow_start = false;
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
@@ -599,7 +616,10 @@ fn peer_choke_recv_supports_fast() {
 
         // Allocate 5 more pieces
         for _ in 0..5 {
-            if let Some((index, _)) = torrent_state.piece_selector.next_piece(key) {
+            if let Some(index) = torrent_state
+                .piece_selector
+                .next_piece(key, &mut connections[key].endgame)
+            {
                 allocated_pieces.push(index);
                 let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
                 connections[key].append_and_fill(&mut subpieces);
@@ -717,7 +737,10 @@ fn peer_choke_recv_does_not_support_fast() {
 
         // Allocate 5 more pieces
         for _ in 0..5 {
-            if let Some((index, _)) = torrent_state.piece_selector.next_piece(key) {
+            if let Some(index) = torrent_state
+                .piece_selector
+                .next_piece(key, &mut connections[key].endgame)
+            {
                 allocated_pieces.push(index);
                 let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
                 connections[key].append_and_fill(&mut subpieces);
@@ -975,10 +998,16 @@ fn interest_is_updated_when_recv_piece() {
                 .bitfield_received(connections[key].conn_id)
         );
 
-        let (index_a, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index_a = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index_a, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
-        let (index_b, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index_b = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index_b, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         assert_eq!(connections[key].inflight.len(), 4);
@@ -1071,10 +1100,16 @@ fn send_have_to_peers_when_piece_completes() {
             &torrent_info,
             scope,
         );
-        let (index_a, _) = torrent_state.piece_selector.next_piece(key_a).unwrap();
+        let index_a = torrent_state
+            .piece_selector
+            .next_piece(key_a, &mut connections[key_a].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index_a, key_a, &file_store);
         connections[key_a].append_and_fill(&mut subpieces);
-        let (index_b, _) = torrent_state.piece_selector.next_piece(key_b).unwrap();
+        let index_b = torrent_state
+            .piece_selector
+            .next_piece(key_b, &mut connections[key_b].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index_b, key_b, &file_store);
         connections[key_b].append_and_fill(&mut subpieces);
 
@@ -1202,7 +1237,10 @@ fn piece_recv() {
             scope,
         );
 
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         let prev_target_infligt = connections[key].target_inflight;
         assert_eq!(torrent_state.num_allocated(), 1);
@@ -1285,7 +1323,10 @@ fn handles_duplicate_piece_recv() {
             scope,
         );
         let prev_target_infligt = connections[key].target_inflight;
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
@@ -1471,7 +1512,10 @@ fn snubbed_peer() {
             scope,
         );
         connections[key].is_interesting = true;
-        let (index, _) = torrent_state.piece_selector.next_piece(key).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
         connections[key].append_and_fill(&mut subpieces);
         assert_eq!(connections[key].inflight.len(), 2);
@@ -1557,7 +1601,10 @@ fn reject_request_requests_new() {
             scope,
         );
         a.is_interesting = true;
-        let (index, _) = torrent_state.piece_selector.next_piece(a.conn_id).unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(a.conn_id, &mut a.endgame)
+            .unwrap();
         let mut subpieces = torrent_state.allocate_piece(index, a.conn_id, &file_store);
         a.append_and_fill(&mut subpieces);
         assert_eq!(a.inflight.len(), 2);
@@ -1716,8 +1763,11 @@ fn endgame_mode() {
         // Set up so that half of the pieces have been requested and that a part of those have been
         // completed
         for i in 0..torrent_state.num_pieces() / 2 {
-            let (index, endgame) = torrent_state.piece_selector.next_piece(key_a).unwrap();
-            assert!(!endgame);
+            let index = torrent_state
+                .piece_selector
+                .next_piece(key_a, &mut connections[key_a].endgame)
+                .unwrap();
+            assert!(!connections[key_a].endgame);
             let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_store);
             connections[key_a].append_and_fill(&mut subpieces);
             if i % 2 == 0 {
@@ -1755,14 +1805,20 @@ fn endgame_mode() {
             - torrent_state.piece_selector.total_completed();
         // request the rest from the other peer so that everything has been allocated
         for _ in 0..remaining {
-            let (index, endgame) = torrent_state.piece_selector.next_piece(key_b).unwrap();
-            assert!(!endgame);
+            let index = torrent_state
+                .piece_selector
+                .next_piece(key_b, &mut connections[key_b].endgame)
+                .unwrap();
+            assert!(!connections[key_b].endgame);
             let mut subpieces = torrent_state.allocate_piece(index, key_b, &file_store);
             connections[key_b].append_and_fill(&mut subpieces);
         }
         for _ in 0..remaining {
-            let (index, endgame) = torrent_state.piece_selector.next_piece(key_a).unwrap();
-            assert!(endgame);
+            let index = torrent_state
+                .piece_selector
+                .next_piece(key_a, &mut connections[key_a].endgame)
+                .unwrap();
+            assert!(connections[key_a].endgame);
             // Never request something we are in the process of downloading
             assert!(
                 !connections[key_a]

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -221,6 +221,11 @@ impl PieceSelector {
     }
 
     #[inline]
+    pub fn is_hashing(&self, index: usize) -> bool {
+        self.hashing_pieces[index]
+    }
+
+    #[inline]
     pub fn is_allocated(&self, index: usize) -> bool {
         self.allocated_pieces[index]
     }

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -60,7 +60,7 @@ impl PieceSelector {
             #[cfg(not(test))]
             rng_gen: SmallRng::from_os_rng(),
             #[cfg(test)]
-            rng_gen: SmallRng::seed_from_u64(0xdeadbeef),
+            rng_gen: SmallRng::seed_from_u64(0xbeefdead),
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,5 +54,5 @@ fn main() {
     let torrrent = Torrent::new(torrent_info, id);
     let start_time = Instant::now();
     torrrent.start(rc, "downloaded").unwrap();
-    log::info!("DOWNLOADED in {}", start_time.elapsed().as_secs());
+    println!("DOWNLOADED in {}", start_time.elapsed().as_secs());
 }

--- a/dashboards.json
+++ b/dashboards.json
@@ -784,6 +784,49 @@
           "legendFormat": "num_pending_connections",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "num_snubbed",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(job) (peer_snubbed)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "num_snubbed",
+          "range": true,
+          "refId": "E",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "eek7csbvj1l34d"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) (peer_endgame)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "endgame",
+          "range": true,
+          "refId": "F"
         }
       ],
       "title": "Connections",
@@ -1003,5 +1046,5 @@
   "timezone": "browser",
   "title": "Throughput",
   "uid": "eebvxemmfqh34d",
-  "version": 28
+  "version": 30
 }

--- a/dashboards.json
+++ b/dashboards.json
@@ -386,12 +386,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "pieces_inflight",
+          "expr": "pieces_allocated",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "inflight",
+          "legendFormat": "allocated",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -716,6 +716,30 @@
                     10
                   ],
                   "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "endgame"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
                 }
               }
             ]
@@ -1046,5 +1070,5 @@
   "timezone": "browser",
   "title": "Throughput",
   "uid": "eebvxemmfqh34d",
-  "version": 30
+  "version": 31
 }


### PR DESCRIPTION
This fixes stalling at the end of downloads due to only a single peer being the one dowloading a piece at a time. After this pr it's possible for multiple peers to be downloading the same piece concurrently. This will happen as soon as a peer have bandwidth left (aka calling next_piece) and there are pieces remaining that are allocated, not hashing and not completed.

To support this `interesting_peer_pieces` now also "switches off" pieces that are picked so that a peer doesn't pick pieces itself allocated. These are "switched on" again when a piece is deallocated to ensure it can be picked again if there is any sort of failure. This meant that the logic that checks if we should send not interested needed to be updated as well. 

I've also updated metric names, and a bunch of test changes so they use `next_piece` more often, to do that I've made the rng predictable when testing.