### PR TITLE
Implement BEP 09 & BEP 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bt_bencode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6398febbe0d54acd58256692c7d0608c0f49741ec830af6918129d6348f5c4bd"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2151,7 @@ version = "0.2.0"
 dependencies = [
  "arbitrary",
  "bitvec",
+ "bt_bencode",
  "bytes",
  "env_logger",
  "io-uring 0.7.5",
@@ -2152,6 +2163,7 @@ dependencies = [
  "metrics-util",
  "rand",
  "rayon",
+ "serde",
  "sha1",
  "slab",
  "smallvec 2.0.0-alpha.11",

--- a/bittorrent/Cargo.toml
+++ b/bittorrent/Cargo.toml
@@ -24,6 +24,8 @@ sha1 = { workspace = true }
 smallvec= { version = "2.0.0-alpha.10" , features = ["std"]}
 rayon = "1"
 metrics = "0.24"
+bt_bencode = "0.8.2"
+serde = { version = "1", features = ["derive"]}
 
 [features]
 fuzzing = ["dep:arbitrary"]

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -13,16 +13,14 @@ use io_uring::{
     opcode,
     types::{self, Timespec},
 };
-use lava_torrent::torrent::v1::Torrent;
 use rayon::Scope;
 use slab::Slab;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
 use crate::{
-    Error, TorrentState,
+    Error, State, StateRef,
     buf_pool::BufferPool,
     buf_ring::{Bgid, BufferRing},
-    file_store::FileStore,
     io_utils::{self, BackloggedSubmissionQueue, SubmissionQueue, UserData},
     peer_connection::{DisconnectReason, OutgoingMsg, PeerConnection},
     peer_protocol::{self, HANDSHAKE_SIZE, PeerId, parse_handshake, write_handshake},
@@ -60,12 +58,12 @@ pub enum Command {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn event_error_handler<Q: SubmissionQueue>(
+fn event_error_handler<'state, Q: SubmissionQueue>(
     sq: &mut BackloggedSubmissionQueue<Q>,
     error_code: u32,
     user_data: UserData,
     events: &mut Slab<EventType>,
-    torrent_state: &mut TorrentState<'_>,
+    state_ref: &mut StateRef<'state>,
     connections: &mut Slab<PeerConnection>,
     pending_connections: &mut HashSet<SockAddr>,
     bgid: Bgid,
@@ -124,9 +122,11 @@ fn event_error_handler<Q: SubmissionQueue>(
                 | EventType::ConnectedWrite { connection_idx } => {
                     let mut connection = connections.remove(connection_idx);
                     log::error!("Peer [{}] Connection reset", connection.peer_id);
-                    connection.release_all_pieces(torrent_state);
-                    if !connection.is_choking {
-                        torrent_state.num_unchoked -= 1;
+                    if let Some((_, torrent_state)) = state_ref.state() {
+                        connection.release_all_pieces(torrent_state);
+                        if !connection.is_choking {
+                            torrent_state.num_unchoked -= 1;
+                        }
                     }
                     io_utils::close_socket(sq, connection.socket, events);
                 }
@@ -143,17 +143,24 @@ fn event_error_handler<Q: SubmissionQueue>(
                     io_utils::close_socket(sq, socket, events);
                 }
                 EventType::ConnectedWrite { connection_idx } => {
-                    let mut connection = connections.remove(connection_idx);
-                    log::error!(
-                        "Peer [{}] EPIPE received when writing to connection",
-                        connection.peer_id
-                    );
-                    connection.release_all_pieces(torrent_state);
-                    // Don't count disconnected peers
-                    if !connection.is_choking {
-                        torrent_state.num_unchoked -= 1;
+                    if let Some(mut connection) = connections.try_remove(connection_idx) {
+                        log::error!(
+                            "Peer [{}] EPIPE received when writing to connection",
+                            connection.peer_id
+                        );
+                        if let Some((_, torrent_state)) = state_ref.state() {
+                            connection.release_all_pieces(torrent_state);
+                            // Don't count disconnected peers
+                            if !connection.is_choking {
+                                torrent_state.num_unchoked -= 1;
+                            }
+                        }
+                        io_utils::close_socket(sq, connection.socket, events);
+                    } else {
+                        // I guess this might happpen when multiple writes are queued up after
+                        // each other
+                        log::warn!("PIPE received after connection has already been removed",);
                     }
-                    io_utils::close_socket(sq, connection.socket, events);
                 }
 
                 _ => unreachable!(),
@@ -203,10 +210,12 @@ fn event_error_handler<Q: SubmissionQueue>(
                     | EventType::Shutdown { connection_idx } => {
                         let mut connection = connections.remove(connection_idx);
                         log::error!("Peer [{}] unhandled error: {err}", connection.peer_id);
-                        connection.release_all_pieces(torrent_state);
-                        // Don't count disconnected peers
-                        if !connection.is_choking {
-                            torrent_state.num_unchoked -= 1;
+                        if let Some((_, torrent_state)) = state_ref.state() {
+                            connection.release_all_pieces(torrent_state);
+                            // Don't count disconnected peers
+                            if !connection.is_choking {
+                                torrent_state.num_unchoked -= 1;
+                            }
                         }
                         io_utils::close_socket(sq, connection.socket, events);
                     }
@@ -259,7 +268,7 @@ pub struct EventLoop {
     our_id: PeerId,
 }
 
-impl<'scope, 'f_store: 'scope> EventLoop {
+impl<'scope, 'state: 'scope> EventLoop {
     pub fn new(our_id: PeerId, events: Slab<EventType>, command_rc: Receiver<Command>) -> Self {
         Self {
             events,
@@ -272,14 +281,12 @@ impl<'scope, 'f_store: 'scope> EventLoop {
         }
     }
 
-    pub fn run(
-        &mut self,
-        mut ring: IoUring,
-        mut torrent_state: TorrentState<'f_store>,
-        file_store: &'f_store FileStore,
-        torrent_info: &'f_store Torrent,
-    ) -> Result<(), Error> {
+    pub fn run(&mut self, mut ring: IoUring, mut state: State) -> Result<(), Error> {
         self.read_ring.register(&ring.submitter())?;
+
+        let mut state_ref = state.as_ref();
+
+        let mut prev_state_initialized = state_ref.is_initialzied();
         // lambda to be able to catch errors an always unregistering the read ring
         let result = rayon::in_place_scope(|scope| {
             let (submitter, sq, mut cq) = ring.split();
@@ -317,9 +324,21 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                         &tick_delta,
                         &mut self.connections,
                         &self.pending_connections,
-                        file_store,
-                        &mut torrent_state,
+                        &mut state_ref,
                     );
+
+                    if !prev_state_initialized && state_ref.is_initialzied() {
+                        prev_state_initialized = true;
+                        for (_, connection) in self.connections.iter_mut() {
+                            let msgs = std::mem::take(&mut connection.pre_meta_have_msgs);
+                            // Get all piece msgs
+                            for msg in msgs {
+                                connection.handle_message(msg, &mut state_ref, scope);
+                            }
+                            // TODO: Trigger unchoked peers
+                        }
+                    }
+
                     last_tick = Instant::now();
                     // Dealt with here to make tick easier to test
                     for (conn_id, connection) in self.connections.iter_mut() {
@@ -340,16 +359,10 @@ impl<'scope, 'f_store: 'scope> EventLoop {
 
                 for cqe in &mut cq {
                     let io_event = IoEvent::from(cqe);
-                    if let Err(err) = self.event_handler(
-                        &mut sq,
-                        io_event,
-                        &mut torrent_state,
-                        file_store,
-                        torrent_info,
-                        scope,
-                    ) {
+                    if let Err(err) = self.event_handler(&mut sq, io_event, &mut state_ref, scope) {
                         log::error!("Error handling event: {err}");
                     }
+
                     // time to return any potential write buffers
                     if let Some(write_idx) = io_event.user_data.buffer_idx {
                         self.write_pool.return_buffer(write_idx as usize);
@@ -361,7 +374,9 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                     }
                 }
 
-                torrent_state.update_torrent_status(&mut self.connections);
+                if let Some((_, torrent_state)) = state_ref.state() {
+                    torrent_state.update_torrent_status(&mut self.connections);
+                }
 
                 for (conn_id, connection) in self.connections.iter_mut() {
                     for msg in connection.outgoing_msgs_buffer.iter_mut() {
@@ -389,9 +404,11 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                     return Ok(());
                 }
 
-                if torrent_state.is_complete {
-                    log::info!("Torrent complete!");
-                    return Ok(());
+                if let Some((_, torrent_state)) = state_ref.state() {
+                    if torrent_state.is_complete {
+                        log::info!("Torrent complete!");
+                        return Ok(());
+                    }
                 }
             }
         });
@@ -509,9 +526,7 @@ impl<'scope, 'f_store: 'scope> EventLoop {
         &mut self,
         sq: &mut BackloggedSubmissionQueue<Q>,
         io_event: IoEvent,
-        torrent_state: &mut TorrentState<'f_store>,
-        file_store: &'f_store FileStore,
-        torrent_info: &'scope Torrent,
+        state: &mut StateRef<'state>,
         scope: &Scope<'scope>,
     ) -> io::Result<()> {
         let ret = match io_event.result {
@@ -522,7 +537,7 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                     error_code,
                     io_event.user_data,
                     &mut self.events,
-                    torrent_state,
+                    state,
                     &mut self.connections,
                     &mut self.pending_connections,
                     self.read_ring.bgid(),
@@ -566,7 +581,7 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                 connect_success_counter.increment(1);
 
                 let buffer = self.write_pool.get_buffer();
-                write_handshake(self.our_id, torrent_state.info_hash, buffer.inner);
+                write_handshake(self.our_id, state.info_hash, buffer.inner);
                 let fd = socket.as_raw_fd();
                 // The event is replaced (this removes the dummy)
                 let old = std::mem::replace(
@@ -677,40 +692,31 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                 // incoming recv cqe
                 let connection = &mut self.connections[conn_id];
                 connection.stateful_decoder.append_data(remainder);
-                let completed = torrent_state.piece_selector.completed_clone();
-                conn_parse_and_handle_msgs(
-                    connection,
-                    torrent_state,
-                    file_store,
-                    torrent_info,
-                    scope,
-                );
+                conn_parse_and_handle_msgs(connection, state, scope);
                 // Recv has been complete, move over to multishot, same user data
                 io_utils::recv_multishot(sq, io_event.user_data, fd, self.read_ring.bgid());
-                let message = if completed.all() {
-                    peer_protocol::PeerMessage::HaveAll
-                } else if completed.not_any() {
-                    peer_protocol::PeerMessage::HaveNone
+
+                let bitfield_msg = if let Some((_, torrent_state)) = state.state() {
+                    let completed = torrent_state.piece_selector.completed_clone();
+                    let message = if completed.all() {
+                        peer_protocol::PeerMessage::HaveAll
+                    } else if completed.not_any() {
+                        peer_protocol::PeerMessage::HaveNone
+                    } else {
+                        peer_protocol::PeerMessage::Bitfield(completed.into())
+                    };
+                    // sent as first message after handshake
+                    OutgoingMsg {
+                        message,
+                        ordered: true,
+                    }
                 } else {
-                    peer_protocol::PeerMessage::Bitfield(completed.into())
+                    OutgoingMsg {
+                        message: peer_protocol::PeerMessage::HaveNone,
+                        ordered: true,
+                    }
                 };
-                // sent as first message after handshake
-                let bitfield_msg = OutgoingMsg {
-                    message,
-                    ordered: true,
-                };
-                let buffer = self.write_pool.get_buffer();
-                bitfield_msg.message.encode(buffer.inner);
-                let size = bitfield_msg.message.encoded_size();
-                io_utils::write_to_connection(
-                    conn_id,
-                    fd,
-                    &mut self.events,
-                    sq,
-                    buffer.index,
-                    &buffer.inner[..size],
-                    bitfield_msg.ordered,
-                );
+                connection.outgoing_msgs_buffer.push(bitfield_msg);
             }
             EventType::ConnectedRecv { connection_idx } => {
                 // The event is reused and not replaced
@@ -726,10 +732,13 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                         connection.peer_id
                     );
                     self.events.remove(io_event.user_data.event_idx as _);
-                    connection.release_all_pieces(torrent_state);
-                    // Don't count disconnected peers
-                    if !connection.is_choking {
-                        torrent_state.num_unchoked -= 1;
+                    // Consider moving to func
+                    if let Some((_, torrent_state)) = state.state() {
+                        connection.release_all_pieces(torrent_state);
+                        // Don't count disconnected peers
+                        if !connection.is_choking {
+                            torrent_state.num_unchoked -= 1;
+                        }
                     }
                     io_utils::close_socket(sq, connection.socket, &mut self.events);
                     return Ok(());
@@ -748,13 +757,7 @@ impl<'scope, 'f_store: 'scope> EventLoop {
                     .unwrap();
                 let buffer = &buffer[..len];
                 connection.stateful_decoder.append_data(buffer);
-                conn_parse_and_handle_msgs(
-                    connection,
-                    torrent_state,
-                    file_store,
-                    torrent_info,
-                    scope,
-                );
+                conn_parse_and_handle_msgs(connection, state, scope);
             }
             EventType::Close => {
                 self.events.remove(io_event.user_data.event_idx as _);
@@ -767,21 +770,13 @@ impl<'scope, 'f_store: 'scope> EventLoop {
 
 fn conn_parse_and_handle_msgs<'scope, 'f_store: 'scope>(
     connection: &mut PeerConnection,
-    torrent_state: &mut TorrentState<'f_store>,
-    file_store: &'f_store FileStore,
-    torrent_info: &'scope Torrent,
+    state: &mut StateRef<'f_store>,
     scope: &Scope<'scope>,
 ) {
     while let Some(parse_result) = connection.stateful_decoder.next() {
         match parse_result {
             Ok(peer_message) => {
-                connection.handle_message(
-                    peer_message,
-                    torrent_state,
-                    file_store,
-                    torrent_info,
-                    scope,
-                );
+                connection.handle_message(peer_message, state, scope);
             }
             Err(err) => {
                 log::error!("Failed {} decoding message: {err}", connection.conn_id);
@@ -794,28 +789,29 @@ fn conn_parse_and_handle_msgs<'scope, 'f_store: 'scope>(
 }
 
 fn report_tick_metrics(
-    torrent_state: &TorrentState<'_>,
+    state: &mut StateRef<'_>,
     connections: &Slab<PeerConnection>,
     pending_connections: &HashSet<SockAddr>,
 ) {
-    let counter = metrics::counter!("pieces_completed");
-    counter.absolute(torrent_state.piece_selector.total_completed() as u64);
-    let gauge = metrics::gauge!("pieces_allocated");
-    gauge.set(torrent_state.piece_selector.total_allocated() as u32);
-    let gauge = metrics::gauge!("num_unchoked");
-    gauge.set(torrent_state.num_unchoked);
+    if let Some((_, torrent_state)) = state.state() {
+        let counter = metrics::counter!("pieces_completed");
+        counter.absolute(torrent_state.piece_selector.total_completed() as u64);
+        let gauge = metrics::gauge!("pieces_allocated");
+        gauge.set(torrent_state.piece_selector.total_allocated() as u32);
+        let gauge = metrics::gauge!("num_unchoked");
+        gauge.set(torrent_state.num_unchoked);
+    }
     let gauge = metrics::gauge!("num_connections");
     gauge.set(connections.len() as u32);
     let gauge = metrics::gauge!("num_pending_connections");
     gauge.set(pending_connections.len() as u32);
 }
 
-pub(crate) fn tick<'scope, 'f_store: 'scope>(
+pub(crate) fn tick<'scope, 'state: 'scope>(
     tick_delta: &Duration,
     connections: &mut Slab<PeerConnection>,
     pending_connections: &HashSet<SockAddr>,
-    file_store: &'f_store FileStore,
-    torrent_state: &mut TorrentState<'scope>,
+    torrent_state: &mut StateRef<'state>,
 ) {
     log::info!("Tick!: {}", tick_delta.as_secs_f32());
     // 1. Calculate bandwidth (deal with initial start up)
@@ -831,82 +827,89 @@ pub(crate) fn tick<'scope, 'f_store: 'scope>(
             connection.pending_disconnect = Some(DisconnectReason::Idle);
             continue;
         }
-        // TODO: If we are not using fast extension this might be triggered by a snub
-        if let Some(time) = connection.last_received_subpiece {
-            if time.elapsed() > connection.request_timeout() {
-                // error just to make more visible
-                log::error!("TIMEOUT: {}", connection.peer_id);
-                connection.on_request_timeout(torrent_state, file_store);
-            } else if connection.snubbed {
-                // Did not timeout
-                connection.snubbed = false;
+        if let Some((file_and_info, torrent_state)) = torrent_state.state() {
+            // TODO: If we are not using fast extension this might be triggered by a snub
+            if let Some(time) = connection.last_received_subpiece {
+                if time.elapsed() > connection.request_timeout() {
+                    // error just to make more visible
+                    log::error!("TIMEOUT: {}", connection.peer_id);
+                    connection.on_request_timeout(torrent_state, &file_and_info.file_store);
+                } else if connection.snubbed {
+                    // Did not timeout
+                    connection.snubbed = false;
+                }
             }
-        }
 
-        // Take delta into account when calculating throughput
-        connection.throughput =
-            (connection.throughput as f64 / tick_delta.as_secs_f64()).round() as u64;
-        if !connection.peer_choking {
-            // slow start win size increase is handled in update_stats
-            if !connection.slow_start {
-                // From the libtorrent impl, request queue time = 3
-                let new_queue_capacity =
-                    3 * connection.throughput / piece_selector::SUBPIECE_SIZE as u64;
-                connection.update_target_inflight(new_queue_capacity as usize);
+            // Take delta into account when calculating throughput
+            connection.throughput =
+                (connection.throughput as f64 / tick_delta.as_secs_f64()).round() as u64;
+            if !connection.peer_choking {
+                // slow start win size increase is handled in update_stats
+                if !connection.slow_start {
+                    // From the libtorrent impl, request queue time = 3
+                    let new_queue_capacity =
+                        3 * connection.throughput / piece_selector::SUBPIECE_SIZE as u64;
+                    connection.update_target_inflight(new_queue_capacity as usize);
+                }
             }
-        }
 
-        if !connection.peer_choking
-            && connection.slow_start
-            && connection.throughput > 0
-            && connection.throughput < connection.prev_throughput + 5000
-        {
-            log::debug!("[Peer {}] Exiting slow start", connection.peer_id);
-            connection.slow_start = false;
-        }
-        connection.prev_throughput = connection.throughput;
-        connection.throughput = 0;
-        // TODO: add to throughput total stats
-    }
-
-    // Request new pieces and fill up request queues
-    let mut peer_bandwidth: Vec<_> = connections
-        .iter_mut()
-        .filter_map(|(key, peer)| {
-            // Skip connections that are pending disconnect
-            if peer.pending_disconnect.is_none() {
-                Some((key, peer.remaining_request_queue_spots()))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    peer_bandwidth.sort_unstable_by(|(_, a), (_, b)| a.cmp(b).reverse());
-    for (peer_key, mut bandwidth) in peer_bandwidth {
-        let peer = &mut connections[peer_key];
-
-        while {
-            let bandwitdth_available_for_new_piece =
-                bandwidth > (torrent_state.piece_selector.avg_num_subpieces() as usize / 2);
-            let nothing_queued = peer.queued.is_empty();
-            (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
-        } {
-            if let Some(next_piece) = torrent_state
-                .piece_selector
-                .next_piece(peer_key, &mut peer.endgame)
+            if !connection.peer_choking
+                && connection.slow_start
+                && connection.throughput > 0
+                && connection.throughput < connection.prev_throughput + 5000
             {
-                let mut queue = torrent_state.allocate_piece(next_piece, peer.conn_id, file_store);
-                let queue_len = queue.len();
-                peer.append_and_fill(&mut queue);
-                // Remove all subpieces from available bandwidth
-                bandwidth -= (queue_len).min(bandwidth);
-            } else {
-                break;
+                log::debug!("[Peer {}] Exiting slow start", connection.peer_id);
+                connection.slow_start = false;
             }
+            connection.prev_throughput = connection.throughput;
+            connection.throughput = 0;
+            // TODO: add to throughput total stats
         }
-        peer.fill_request_queue();
-        peer.report_metrics();
+    }
+    if let Some((file_and_info, torrent_state)) = torrent_state.state() {
+        // Request new pieces and fill up request queues
+        let mut peer_bandwidth: Vec<_> = connections
+            .iter_mut()
+            .filter_map(|(key, peer)| {
+                // Skip connections that are pending disconnect
+                if peer.pending_disconnect.is_none() {
+                    Some((key, peer.remaining_request_queue_spots()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        peer_bandwidth.sort_unstable_by(|(_, a), (_, b)| a.cmp(b).reverse());
+        for (peer_key, mut bandwidth) in peer_bandwidth {
+            let peer = &mut connections[peer_key];
+
+            while {
+                let bandwitdth_available_for_new_piece =
+                    bandwidth > (torrent_state.piece_selector.avg_num_subpieces() as usize / 2);
+                let nothing_queued = peer.queued.is_empty();
+                (bandwitdth_available_for_new_piece || nothing_queued) && !peer.peer_choking
+            } {
+                if let Some(next_piece) = torrent_state
+                    .piece_selector
+                    .next_piece(peer_key, &mut peer.endgame)
+                {
+                    let mut queue = torrent_state.allocate_piece(
+                        next_piece,
+                        peer.conn_id,
+                        &file_and_info.file_store,
+                    );
+                    let queue_len = queue.len();
+                    peer.append_and_fill(&mut queue);
+                    // Remove all subpieces from available bandwidth
+                    bandwidth -= (queue_len).min(bandwidth);
+                } else {
+                    break;
+                }
+            }
+            peer.fill_request_queue();
+            peer.report_metrics();
+        }
     }
 
     report_tick_metrics(torrent_state, connections, pending_connections);

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -938,8 +938,7 @@ mod tests {
         let debbuging = DebuggingRecorder::new();
         let snapshotter = debbuging.snapshotter();
         // Setup test environment
-        let (file_store, torrent_info) = setup_test();
-        let torrent_state = TorrentState::new(&torrent_info);
+
         let (tx, rx) = mpsc::channel();
 
         // Create a listener that will accept connections but not respond
@@ -955,6 +954,7 @@ mod tests {
             std::thread::sleep(Duration::from_secs(HANDSHAKE_TIMEOUT_SECS + 1));
         });
         let event_loop_thread = std::thread::spawn(move || {
+            let download_state = setup_test();
             metrics::with_local_recorder(&debbuging, || {
                 let our_id = generate_peer_id();
                 let mut event_loop = EventLoop::new(our_id, Slab::new(), rx);
@@ -966,7 +966,7 @@ mod tests {
                     .setup_coop_taskrun()
                     .build(4096)
                     .unwrap();
-                let result = event_loop.run(ring, torrent_state, &file_store, &torrent_info);
+                let result = event_loop.run(ring, download_state);
                 assert!(result.is_ok());
             })
         });

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -144,6 +144,7 @@ fn event_error_handler<'state, Q: SubmissionQueue>(
                     io_utils::close_socket(sq, socket, events);
                 }
                 EventType::ConnectedWrite { connection_idx } => {
+                    // TODO: CANCEL EPIPE CONNS
                     if let Some(mut connection) = connections.try_remove(connection_idx) {
                         log::error!(
                             "Peer [{}] EPIPE received when writing to connection",
@@ -163,7 +164,6 @@ fn event_error_handler<'state, Q: SubmissionQueue>(
                         log::warn!("PIPE received after connection has already been removed",);
                     }
                 }
-
                 _ => unreachable!(),
             }
             Ok(())
@@ -199,6 +199,7 @@ fn event_error_handler<'state, Q: SubmissionQueue>(
                 );
             } else {
                 let event = events.remove(user_data.event_idx as _);
+                log::error!("Unhandled error of typ: {event:?}");
                 match event {
                     EventType::Connect { socket, addr: _ }
                     | EventType::Write { socket, addr: _ }

--- a/bittorrent/src/peer_comm/extended_protocol.rs
+++ b/bittorrent/src/peer_comm/extended_protocol.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeMap;
+
+use bitvec::{boxed::BitBox, vec::BitVec};
+use bt_bencode::{Deserializer, Value};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+
+use crate::{StateRef, event_loop::MAX_OUTSTANDING_REQUESTS, piece_selector::SUBPIECE_SIZE};
+
+use super::{
+    peer_connection::{DisconnectReason, OutgoingMsg},
+    peer_protocol::PeerMessage,
+};
+
+// Supported extensions and this clients ID for them
+pub const EXTENSIONS: [(&str, u8); 1] = [("ut_metadata", 1)];
+
+/// The handshake message this peer should send to anyone supporting the
+/// extension
+pub fn extension_handshake_msg(state_ref: &mut StateRef) -> PeerMessage {
+    let mut handshake = BTreeMap::new();
+    let extensions: BTreeMap<_, _> = BTreeMap::from(EXTENSIONS);
+    handshake.insert("m", bt_bencode::value::to_value(&extensions).unwrap());
+    handshake.insert(
+        "v",
+        bt_bencode::value::to_value(&format!("Vortex {}", env!("CARGO_PKG_VERSION"))).unwrap(),
+    );
+    if let Some((file_and_meta, _)) = state_ref.state() {
+        let metadata_size = file_and_meta.metadata.construct_info().encode().len();
+        handshake.insert(
+            "metadata_size",
+            bt_bencode::to_value(&metadata_size).unwrap(),
+        );
+    }
+    handshake.insert(
+        "reqq",
+        bt_bencode::value::to_value(&MAX_OUTSTANDING_REQUESTS).unwrap(),
+    );
+    PeerMessage::Extended {
+        id: 0,
+        data: bt_bencode::to_vec(&handshake).unwrap().into(),
+    }
+}
+
+pub trait ExtensionProtocol {
+    fn handle_message<'f_store>(
+        &mut self,
+        data: Bytes,
+        state: &mut StateRef<'f_store>,
+        outgoing_msgs_buffer: &mut Vec<OutgoingMsg>,
+    ) -> Result<(), DisconnectReason>;
+    // TODO: fn tick?
+}
+
+const REQUEST: u8 = 0;
+const DATA: u8 = 1;
+const REJECT: u8 = 2;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct MetadataMessage {
+    pub msg_type: u8,
+    pub piece: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_size: Option<i32>,
+}
+
+// BEP 9
+pub struct MetadataExtension {
+    // The peers ID for the extension
+    id: u8,
+    metadata: Vec<u8>,
+    inflight: BitBox,
+    completed: BitBox,
+}
+
+impl MetadataExtension {
+    pub fn new(id: u8, metadata_size: usize) -> Self {
+        let num_pieces = metadata_size / SUBPIECE_SIZE as usize
+            + if metadata_size % SUBPIECE_SIZE as usize != 0 {
+                1
+            } else {
+                0
+            };
+        let inflight: BitBox = BitVec::repeat(false, num_pieces).into();
+        let completed: BitBox = BitVec::repeat(false, num_pieces).into();
+        Self {
+            id,
+            metadata: vec![0; metadata_size],
+            inflight,
+            completed,
+        }
+    }
+
+    pub fn num_pieces(&self) -> usize {
+        self.inflight.len()
+    }
+
+    pub fn request(&mut self, piece: i32) -> PeerMessage {
+        self.inflight.set(piece as usize, true);
+        let req = MetadataMessage {
+            msg_type: REQUEST,
+            piece,
+            total_size: None,
+        };
+        PeerMessage::Extended {
+            id: self.id,
+            data: bt_bencode::to_vec(&req).expect("valid bencode").into(),
+        }
+    }
+
+    pub fn data(&mut self, piece: i32, metadata_piece: &[u8]) -> PeerMessage {
+        let req = MetadataMessage {
+            msg_type: DATA,
+            piece,
+            // Note this is NOT the length of the piece
+            total_size: Some(self.metadata.len() as i32),
+        };
+        let mut data: Vec<u8> = bt_bencode::to_vec(&req).expect("valid bencode");
+        data.extend_from_slice(metadata_piece);
+        PeerMessage::Extended {
+            id: self.id,
+            data: data.into(),
+        }
+    }
+
+    pub fn reject(&mut self, piece: i32) -> PeerMessage {
+        let req = MetadataMessage {
+            msg_type: REJECT,
+            piece,
+            total_size: None,
+        };
+        PeerMessage::Extended {
+            id: self.id,
+            data: bt_bencode::to_vec(&req).expect("valid bencode").into(),
+        }
+    }
+}
+
+impl ExtensionProtocol for MetadataExtension {
+    fn handle_message<'state>(
+        &mut self,
+        data: Bytes,
+        state: &mut StateRef<'state>,
+        outgoing_msgs_buffer: &mut Vec<OutgoingMsg>,
+    ) -> Result<(), DisconnectReason> {
+        // TODO: Consider reusing this
+        let mut de = Deserializer::from_slice(&data[..]);
+        let message: MetadataMessage = <MetadataMessage>::deserialize(&mut de)
+            .map_err(|_err| DisconnectReason::ProtocolError("Invalid metadata message"))?;
+        log::trace!(
+            "Got metadata extension message of type: {}",
+            message.msg_type
+        );
+        match message.msg_type {
+            REQUEST => {
+                // if we do not have all metadata yet then reject the requests
+                if let Some((file_and_meta, _)) = state.state() {
+                    let info_bytes = file_and_meta.metadata.construct_info().encode();
+                    let piece_idx = usize::try_from(message.piece).map_err(|_err| {
+                        DisconnectReason::ProtocolError("Invalid metadata piece index")
+                    })?;
+                    let Some(start_offset) = piece_idx.checked_mul(SUBPIECE_SIZE as usize) else {
+                        return Err(DisconnectReason::ProtocolError(
+                            "Invalid metadata piece index",
+                        ));
+                    };
+                    if start_offset >= info_bytes.len() {
+                        outgoing_msgs_buffer.push(OutgoingMsg {
+                            message: self.reject(message.piece),
+                            ordered: false,
+                        });
+                    } else {
+                        let metadata_piece = &info_bytes[start_offset..];
+                        outgoing_msgs_buffer.push(OutgoingMsg {
+                            message: self.data(message.piece, metadata_piece),
+                            ordered: false,
+                        });
+                    }
+                } else {
+                    outgoing_msgs_buffer.push(OutgoingMsg {
+                        message: self.reject(message.piece),
+                        ordered: false,
+                    });
+                }
+                de.end().map_err(|_err| {
+                    DisconnectReason::ProtocolError("Metadata request message longer than expected")
+                })?;
+            }
+            DATA => {
+                // We race compiletion of the metadata so we might
+                // receive DATA messages late, in that case we ignore them
+                if state.is_initialzied() {
+                    return Ok(());
+                }
+                let end = ((SUBPIECE_SIZE * message.piece + SUBPIECE_SIZE) as usize)
+                    .min(self.metadata.len());
+                let actual_data = &data[de.byte_offset()..];
+                self.metadata[(SUBPIECE_SIZE * message.piece) as usize..end]
+                    .copy_from_slice(actual_data);
+
+                self.completed.set(message.piece as usize, true);
+                if let Some(index) = self.inflight.first_zero() {
+                    outgoing_msgs_buffer.push(OutgoingMsg {
+                        message: self.request(index as i32),
+                        ordered: false,
+                    });
+                } else if self.completed.all() {
+                    let mut hasher = Sha1::new();
+                    hasher.update(&self.metadata);
+                    let hash = hasher.finalize();
+
+                    if hash.as_slice() != state.info_hash() {
+                        log::error!("Got wrong hash for metadata");
+                        return Err(DisconnectReason::ProtocolError("Metadata hash mismatch"));
+                    } else if state.state().is_none() {
+                        let metadata: Value =
+                            bt_bencode::from_slice(&self.metadata).map_err(|_err| {
+                                DisconnectReason::ProtocolError("Metadata not parsable")
+                            })?;
+                        let mut parsable = BTreeMap::new();
+                        parsable.insert("info", metadata);
+                        let torrent = lava_torrent::torrent::v1::Torrent::read_from_bytes(
+                            // should never panic
+                            bt_bencode::to_vec(&parsable).unwrap().as_slice(),
+                        )
+                        .expect("metadata to be parsable");
+                        state.init(torrent).expect("State to be initialized once");
+                    }
+                }
+            }
+            REJECT => {
+                self.inflight.set(message.piece as usize, true);
+                log::warn!("Got reject request");
+                de.end().map_err(|_err| {
+                    DisconnectReason::ProtocolError("Metadata request message longer than expected")
+                })?;
+            }
+            typ => {
+                log::error!("Got metadata extension unknown type: {typ}");
+            }
+        }
+        Ok(())
+    }
+}

--- a/bittorrent/src/peer_comm/mod.rs
+++ b/bittorrent/src/peer_comm/mod.rs
@@ -1,5 +1,5 @@
-pub mod peer_connection;
 pub mod extended_protocol;
+pub mod peer_connection;
 pub mod peer_protocol;
 
 #[cfg(test)]

--- a/bittorrent/src/peer_comm/mod.rs
+++ b/bittorrent/src/peer_comm/mod.rs
@@ -1,4 +1,5 @@
 pub mod peer_connection;
+pub mod extended_protocol;
 pub mod peer_protocol;
 
 #[cfg(test)]

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -1,11 +1,13 @@
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     net::Ipv4Addr,
     time::{Duration, Instant},
 };
 
+use bt_bencode::{Deserializer, Value};
 use bytes::Bytes;
 use rayon::Scope;
+use serde::Deserialize;
 use sha1::Digest;
 use socket2::Socket;
 

--- a/bittorrent/src/peer_comm/peer_protocol.rs
+++ b/bittorrent/src/peer_comm/peer_protocol.rs
@@ -72,7 +72,7 @@ impl<'a> arbitrary::Arbitrary<'a> for PeerMessage {
 
 pub fn generate_peer_id() -> PeerId {
     // Based on http://www.bittorrent.org/beps/bep_0020.html
-    const PREFIX: [u8; 8] = *b"-VT0010-";
+    const PREFIX: [u8; 8] = *b"-VT0020-";
     let generatated = rand::random::<[u8; 12]>();
     let mut result: [u8; 20] = [0; 20];
     result[0..8].copy_from_slice(&PREFIX);

--- a/bittorrent/src/peer_comm/peer_protocol.rs
+++ b/bittorrent/src/peer_comm/peer_protocol.rs
@@ -87,6 +87,7 @@ pub fn write_handshake(our_peer_id: PeerId, info_hash: [u8; 20], mut buffer: &mu
     buffer.put_u8(PROTOCOL.len() as u8);
     buffer.put_slice(PROTOCOL);
     let mut extension = [0_u8; 8];
+    extension[5] |= 0x10;
     extension[7] |= 0x04;
     buffer.put_slice(&extension as &[u8]);
     buffer.put_slice(&info_hash as &[u8]);
@@ -117,6 +118,7 @@ impl Display for PeerId {
 pub struct ParsedHandshake {
     pub peer_id: PeerId,
     pub fast_ext: bool,
+    pub extension_protocol: bool,
 }
 
 pub fn parse_handshake(info_hash: [u8; 20], mut buffer: &[u8]) -> io::Result<ParsedHandshake> {
@@ -129,8 +131,9 @@ pub fn parse_handshake(info_hash: [u8; 20], mut buffer: &[u8]) -> io::Result<Par
         return Err(ErrorKind::InvalidData.into());
     }
     buffer.advance(str_len);
-    // Extensions, only fast ext is checked for now
+    // Extensions
     let fast_ext = buffer[7] & 0x04 != 0;
+    let extension_protocol = buffer[5] & 0x10 != 0;
     buffer.advance(8);
     let peer_info_hash: [u8; 20] = buffer[..20]
         .try_into()
@@ -144,6 +147,7 @@ pub fn parse_handshake(info_hash: [u8; 20], mut buffer: &[u8]) -> io::Result<Par
         .map_err(|_err| ErrorKind::InvalidData)?;
     Ok(ParsedHandshake {
         peer_id: PeerId(peer_id),
+        extension_protocol,
         fast_ext,
     })
 }
@@ -164,23 +168,25 @@ pub enum PeerMessage {
     SuggestPiece { index: i32 },
     Cancel { index: i32, begin: i32, length: i32 },
     Piece { index: i32, begin: i32, data: Bytes },
+    Extended { id: u8, data: Bytes },
 }
 
 impl PeerMessage {
-    pub const CHOKE: u8 = 0;
-    pub const UNCHOKE: u8 = 1;
-    pub const INTERESTED: u8 = 2;
-    pub const NOT_INTERESTED: u8 = 3;
-    pub const HAVE: u8 = 4;
-    pub const BITFIELD: u8 = 5;
-    pub const REQUEST: u8 = 6;
-    pub const PIECE: u8 = 7;
-    pub const CANCEL: u8 = 8;
-    pub const HAVE_ALL: u8 = 0x0E;
-    pub const HAVE_NONE: u8 = 0x0F;
-    pub const SUGGEST_PIECE: u8 = 0x0D;
-    pub const REJECT_REQUEST: u8 = 0x10;
-    pub const ALLOWED_FAST: u8 = 0x11;
+    const CHOKE: u8 = 0;
+    const UNCHOKE: u8 = 1;
+    const INTERESTED: u8 = 2;
+    const NOT_INTERESTED: u8 = 3;
+    const HAVE: u8 = 4;
+    const BITFIELD: u8 = 5;
+    const REQUEST: u8 = 6;
+    const PIECE: u8 = 7;
+    const CANCEL: u8 = 8;
+    const HAVE_ALL: u8 = 0x0E;
+    const HAVE_NONE: u8 = 0x0F;
+    const SUGGEST_PIECE: u8 = 0x0D;
+    const REJECT_REQUEST: u8 = 0x10;
+    const ALLOWED_FAST: u8 = 0x11;
+    const EXTENDED: u8 = 20;
 
     // TODO: make const and use of this more
     pub fn encoded_size(&self) -> usize {
@@ -199,6 +205,7 @@ impl PeerMessage {
             | PeerMessage::RejectRequest { .. }
             | PeerMessage::Cancel { .. } => 13,
             PeerMessage::Piece { data, .. } => 9 + data.len(),
+            PeerMessage::Extended { data, .. } => 2 + data.len(),
         };
         // Length prefix + message
         std::mem::size_of::<i32>() + message_size
@@ -276,6 +283,11 @@ impl PeerMessage {
                 buf.put_u8(Self::PIECE);
                 buf.put_i32(*index);
                 buf.put_i32(*begin);
+                buf.put_slice(data);
+            }
+            PeerMessage::Extended { id, data } => {
+                buf.put_u8(Self::EXTENDED);
+                buf.put_u8(*id);
                 buf.put_slice(data);
             }
         }
@@ -420,6 +432,15 @@ pub fn parse_message(mut data: Bytes) -> io::Result<PeerMessage> {
                 index: data.get_i32(),
                 begin: data.get_i32(),
                 length: data.get_i32(),
+            })
+        }
+        PeerMessage::EXTENDED => {
+            if data.remaining() < 1 {
+                return Err(io::ErrorKind::InvalidData.into());
+            }
+            Ok(PeerMessage::Extended {
+                id: data.get_u8(),
+                data,
             })
         }
         _ => Err(io::ErrorKind::InvalidData.into()),

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -1,14 +1,15 @@
 use std::time::{Duration, Instant};
 
+use bt_bencode::Deserializer;
+use serde::Deserialize;
 use slab::Slab;
 
 use crate::{
-    TorrentState,
-    event_loop::tick,
-    peer_comm::peer_connection::DisconnectReason,
+    event_loop::{MAX_OUTSTANDING_REQUESTS, tick},
+    peer_comm::{extended_protocol::MetadataMessage, peer_connection::DisconnectReason},
     peer_connection::OutgoingMsg,
     piece_selector::{SUBPIECE_SIZE, Subpiece},
-    test_utils::{generate_peer, setup_test},
+    test_utils::{generate_peer, setup_test, setup_uninitialized_test, setup_uninitialized_test_with_metadata_size},
 };
 
 use super::{peer_connection::PeerConnection, peer_protocol::PeerMessage};
@@ -43,22 +44,19 @@ fn sent_and_marked_not_interested(peer: &PeerConnection) {
 
 #[test]
 fn fast_ext_have_all() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
         assert!(!a.is_interesting);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(a.conn_id));
         sent_and_marked_interested(&a);
         assert!(a.pending_disconnect.is_none());
-        for piece_id in 0..torrent_info.pieces.len() {
+        for piece_id in 0..file_and_info.metadata.pieces.len() {
             assert!(
                 torrent_state
                     .piece_selector
@@ -69,26 +67,16 @@ fn fast_ext_have_all() {
 
         // Peers that do not state they support fast_ext are disconnected
         let mut b = generate_peer(false, 1);
-        b.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        b.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         assert!(b.pending_disconnect.is_some());
 
         // Do not mark as interestead if we've already completed the torrent
         let mut a = generate_peer(true, 3);
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.is_complete = true;
         assert!(!a.is_interesting);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(a.conn_id));
         assert!(!a.is_interesting);
     });
@@ -96,20 +84,17 @@ fn fast_ext_have_all() {
 
 #[test]
 fn fast_ext_have_none() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
         a.is_interesting = true;
-        a.handle_message(
-            PeerMessage::HaveNone,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::HaveNone, &mut state_ref, scope);
         // we are not interestead in peers that have nothing
         sent_and_marked_not_interested(&a);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(a.conn_id));
         assert!(a.pending_disconnect.is_none());
         assert!(
@@ -121,39 +106,30 @@ fn fast_ext_have_none() {
         );
         // Peers that do not state they support fast_ext are disconnected
         let mut b = generate_peer(false, 1);
-        b.handle_message(
-            PeerMessage::HaveNone,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        b.handle_message(PeerMessage::HaveNone, &mut state_ref, scope);
         assert!(b.pending_disconnect.is_some());
     });
 }
 
 #[test]
 fn have() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key_a = connections.insert(a);
-        connections[key_a].handle_message(
-            PeerMessage::Have { index: 7 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_a].handle_message(PeerMessage::Have { index: 7 }, &mut state_ref, scope);
         // Interpret the Have as HaveNone, the bitfield might have been omitted
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(key_a));
         assert!(connections[key_a].pending_disconnect.is_none());
         // We should be interestead now since we do not have the piece
         sent_and_marked_interested(&connections[key_a]);
         connections[key_a].outgoing_msgs_buffer.clear();
-        for piece_id in 0..torrent_info.pieces.len() {
+        for piece_id in 0..file_and_info.metadata.pieces.len() {
             if piece_id == 7 {
                 assert!(
                     torrent_state
@@ -171,35 +147,27 @@ fn have() {
             }
         }
         // Does not send interested again
-        connections[key_a].handle_message(
-            PeerMessage::Have { index: 7 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_a].handle_message(PeerMessage::Have { index: 7 }, &mut state_ref, scope);
         assert!(connections[key_a].outgoing_msgs_buffer.is_empty());
+        let (_, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key_a, &mut connections[key_a].endgame)
             .unwrap();
         assert_eq!(index, 7);
-        let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_and_info.file_store);
         connections[key_a].append_and_fill(&mut subpieces);
 
         let b = generate_peer(true, 1);
         let key_b = connections.insert(b);
         assert!(!connections[key_b].is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.is_allocated(index as usize));
-        connections[key_b].handle_message(
-            PeerMessage::Have { index },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_b].handle_message(PeerMessage::Have { index }, &mut state_ref, scope);
         // Piece is still interesting since it's not completed
         sent_and_marked_interested(&connections[key_b]);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(
             torrent_state
                 .piece_selector
@@ -217,9 +185,7 @@ fn have() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key_a].handle_message(
@@ -228,12 +194,11 @@ fn have() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(connections[key_a].inflight.is_empty());
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 0);
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
@@ -241,15 +206,10 @@ fn have() {
 
         // C is not interesting
         assert!(!connections[key_c].is_interesting);
-        connections[key_c].handle_message(
-            PeerMessage::Have { index },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_c].handle_message(PeerMessage::Have { index }, &mut state_ref, scope);
         // Piece is NOT interesting since it's completed
         assert!(!connections[key_c].is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(
             !torrent_state
                 .piece_selector
@@ -261,26 +221,21 @@ fn have() {
 
 #[test]
 fn have_invalid_indicies() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::Have { index: -1 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::Have { index: -1 }, &mut state_ref, scope);
         assert!(a.pending_disconnect.is_some());
         let mut b = generate_peer(false, 0);
+        let (_, torrent_state) = state_ref.state().unwrap();
         b.handle_message(
             PeerMessage::Have {
                 index: torrent_state.num_pieces() as i32,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(b.pending_disconnect.is_some());
@@ -289,20 +244,18 @@ fn have_invalid_indicies() {
 
 #[test]
 fn have_without_interest() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    // Needed to avoid hitting asserts
-    torrent_state.piece_selector.mark_complete(8);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let (_, torrent_state) = state_ref.state().unwrap();
+        // Needed to avoid hitting asserts
+        torrent_state.piece_selector.mark_complete(8);
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::Have { index: 8 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::Have { index: 8 }, &mut state_ref, scope);
         // Interpret the Have as HaveNone, the bitfield might have been omitted
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(a.conn_id));
         assert!(a.pending_disconnect.is_none());
         // We should not be interestead now since we do already have the piece
@@ -319,9 +272,11 @@ fn have_without_interest() {
 
 #[test]
 fn slow_start() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
@@ -329,8 +284,7 @@ fn slow_start() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].prev_throughput, 0);
@@ -343,20 +297,16 @@ fn slow_start() {
         // To control exactly how much is requested we set up
         // Have messages just before next_piece calls, otherwise
         // tick will allocate other pieces
-        connections[key].handle_message(
-            PeerMessage::Have { index: 1 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Have { index: 1 }, &mut state_ref, scope);
 
+        let (_, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
         assert_eq!(index, 1);
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
             PeerMessage::Piece {
@@ -364,9 +314,7 @@ fn slow_start() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -375,9 +323,7 @@ fn slow_start() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert_eq!(connections[key].throughput, (SUBPIECE_SIZE * 2) as u64);
@@ -389,8 +335,7 @@ fn slow_start() {
             &Duration::from_millis(1500),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         assert_eq!(connections[key].prev_throughput, 21845);
@@ -398,19 +343,15 @@ fn slow_start() {
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 2);
 
-        connections[key].handle_message(
-            PeerMessage::Have { index: 2 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Have { index: 2 }, &mut state_ref, scope);
+        let (_, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
         assert_eq!(index, 2);
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
             PeerMessage::Piece {
@@ -418,9 +359,7 @@ fn slow_start() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -429,9 +368,7 @@ fn slow_start() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
 
@@ -439,28 +376,23 @@ fn slow_start() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         assert_eq!(connections[key].prev_throughput, (SUBPIECE_SIZE * 2) as u64);
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 4);
 
-        connections[key].handle_message(
-            PeerMessage::Have { index: 3 },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Have { index: 3 }, &mut state_ref, scope);
 
+        let (_, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
         assert_eq!(index, 3);
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
             PeerMessage::Piece {
@@ -468,9 +400,7 @@ fn slow_start() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -479,9 +409,7 @@ fn slow_start() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
 
@@ -489,8 +417,7 @@ fn slow_start() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         assert_eq!(connections[key].prev_throughput, (SUBPIECE_SIZE * 2) as u64);
@@ -502,27 +429,25 @@ fn slow_start() {
 
 #[test]
 fn desired_queue_size() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
-        connections[key].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         connections[key].peer_choking = false;
         connections[key].slow_start = false;
+        let (_, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
             PeerMessage::Piece {
@@ -530,9 +455,7 @@ fn desired_queue_size() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -541,9 +464,7 @@ fn desired_queue_size() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
 
@@ -551,8 +472,7 @@ fn desired_queue_size() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         // 2 subpieces * 3
@@ -562,8 +482,7 @@ fn desired_queue_size() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         // Never go below 1
@@ -576,57 +495,52 @@ fn desired_queue_size() {
 // when receving chokes
 #[test]
 fn peer_choke_recv_supports_fast() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
         // First, the peer needs to have pieces to be interesting
         for index in 1..7 {
-            connections[key].handle_message(
-                PeerMessage::Have { index },
-                &mut torrent_state,
-                &file_store,
-                &torrent_info,
-                scope,
-            );
+            connections[key].handle_message(PeerMessage::Have { index }, &mut state_ref, scope);
         }
 
         connections[key].slow_start = false;
 
         assert!(connections[key].peer_choking);
-        connections[key].handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         assert!(!connections[key].peer_choking);
 
         // Now allocate additional pieces manually
         let mut allocated_pieces = Vec::new();
 
         // Get the first piece that was allocated during unchoke
+        let (_, torrent_state) = state_ref.state().unwrap();
         if let Some(piece) = torrent_state.pieces.iter().position(|p| p.is_some()) {
             allocated_pieces.push(piece as i32);
         }
 
         // Allocate 5 more pieces
         for _ in 0..5 {
+            let (_, torrent_state) = state_ref.state().unwrap();
             if let Some(index) = torrent_state
                 .piece_selector
                 .next_piece(key, &mut connections[key].endgame)
             {
                 allocated_pieces.push(index);
-                let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+                let (file_and_info, torrent_state) = state_ref.state().unwrap();
+                let mut subpieces =
+                    torrent_state.allocate_piece(index, key, &file_and_info.file_store);
                 connections[key].append_and_fill(&mut subpieces);
             }
         }
 
         assert_eq!(allocated_pieces.len(), 6);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 6);
         assert_eq!(connections[key].target_inflight, 4);
         assert_eq!(connections[key].queued.len(), 8);
@@ -640,9 +554,7 @@ fn peer_choke_recv_supports_fast() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -651,9 +563,7 @@ fn peer_choke_recv_supports_fast() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
 
@@ -661,8 +571,7 @@ fn peer_choke_recv_supports_fast() {
             &Duration::from_millis(650),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         // Want an odd number here to test releasing in flight pieces
@@ -672,20 +581,16 @@ fn peer_choke_recv_supports_fast() {
 
         for index in allocated_pieces.iter().skip(1) {
             // The last allocated piece should still be allocated
+            let (_, torrent_state) = state_ref.state().unwrap();
             assert!(torrent_state.piece_selector.is_allocated(*index as usize));
         }
-        connections[key].handle_message(
-            PeerMessage::Choke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Choke, &mut state_ref, scope);
         assert!(connections[key].peer_choking);
         assert_eq!(connections[key].target_inflight, 9);
         assert_eq!(connections[key].inflight.len(), 9);
         assert!(connections[key].queued.is_empty());
         // 1 piece completed (pending hashing), one was released
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 4);
         assert!(
             !torrent_state
@@ -697,57 +602,52 @@ fn peer_choke_recv_supports_fast() {
 
 #[test]
 fn peer_choke_recv_does_not_support_fast() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(false, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
         // First, the peer needs to have pieces to be interesting
         for index in 1..7 {
-            connections[key].handle_message(
-                PeerMessage::Have { index },
-                &mut torrent_state,
-                &file_store,
-                &torrent_info,
-                scope,
-            );
+            connections[key].handle_message(PeerMessage::Have { index }, &mut state_ref, scope);
         }
 
         connections[key].slow_start = false;
 
         assert!(connections[key].peer_choking);
-        connections[key].handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         assert!(!connections[key].peer_choking);
 
         // Now allocate additional pieces manually
         let mut allocated_pieces = Vec::new();
 
         // Get the first piece that was allocated during unchoke
+        let (_, torrent_state) = state_ref.state().unwrap();
         if let Some(piece) = torrent_state.pieces.iter().position(|p| p.is_some()) {
             allocated_pieces.push(piece as i32);
         }
 
         // Allocate 5 more pieces
         for _ in 0..5 {
+            let (_, torrent_state) = state_ref.state().unwrap();
             if let Some(index) = torrent_state
                 .piece_selector
                 .next_piece(key, &mut connections[key].endgame)
             {
                 allocated_pieces.push(index);
-                let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+                let (file_and_info, torrent_state) = state_ref.state().unwrap();
+                let mut subpieces =
+                    torrent_state.allocate_piece(index, key, &file_and_info.file_store);
                 connections[key].append_and_fill(&mut subpieces);
             }
         }
 
         assert_eq!(allocated_pieces.len(), 6);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 6);
         assert_eq!(connections[key].target_inflight, 4);
         assert_eq!(connections[key].queued.len(), 8);
@@ -761,9 +661,7 @@ fn peer_choke_recv_does_not_support_fast() {
                 begin: 0,
                 data: vec![1; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -772,9 +670,7 @@ fn peer_choke_recv_does_not_support_fast() {
                 begin: SUBPIECE_SIZE,
                 data: vec![2; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
 
@@ -782,32 +678,27 @@ fn peer_choke_recv_does_not_support_fast() {
             &Duration::from_millis(650),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
 
         // Want an odd number here to test releasing in flight pieces
         assert_eq!(connections[key].target_inflight, 9);
         assert_eq!(connections[key].inflight.len(), 9);
         assert_eq!(connections[key].queued.len(), 1);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(
             torrent_state
                 .piece_selector
                 .is_allocated(*allocated_pieces.last().unwrap() as usize)
         );
 
-        connections[key].handle_message(
-            PeerMessage::Choke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Choke, &mut state_ref, scope);
         assert!(connections[key].peer_choking);
         assert_eq!(connections[key].target_inflight, 9);
         assert_eq!(connections[key].inflight.len(), 0);
         assert_eq!(connections[key].queued.len(), 0);
         // 1 piece completed (pending hashing), one was released
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 0);
         // index = first_piece is not inflight over the network but pending hashing and thus is
         // still marked inflight
@@ -819,50 +710,36 @@ fn peer_choke_recv_does_not_support_fast() {
 
 #[test]
 fn unchoke_recv() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(false, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
         assert!(connections[key].peer_choking);
         connections[key].is_interesting = false;
-        connections[key].handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         assert!(!connections[key].peer_choking);
         // No intrest so nothing is downloaded
         assert!(connections[key].queued.is_empty());
         assert!(connections[key].inflight.is_empty());
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 0);
 
         let a = generate_peer(true, 1);
         let mut connections = Slab::new();
         let key = connections.insert(a);
-        connections[key].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         assert!(connections[key].peer_choking);
         assert!(connections[key].is_interesting);
-        connections[key].handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         assert!(!connections[key].peer_choking);
         // Peer is interesting so we start downloading
         assert!(!(connections[key].queued.is_empty() && connections[key].inflight.is_empty()));
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(!torrent_state.pieces.is_empty());
     });
 }
@@ -871,39 +748,32 @@ fn unchoke_recv() {
 
 #[test]
 fn bitfield_recv() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         {
             let mut b = generate_peer(true, 0);
             assert!(b.pending_disconnect.is_none());
+            let (_, torrent_state) = state_ref.state().unwrap();
             let invalid_field =
                 bitvec::bitvec!(u8, bitvec::order::Msb0; 1; torrent_state.num_pieces() - 1);
-            b.handle_message(
-                PeerMessage::Bitfield(invalid_field),
-                &mut torrent_state,
-                &file_store,
-                &torrent_info,
-                scope,
-            );
+            b.handle_message(PeerMessage::Bitfield(invalid_field), &mut state_ref, scope);
             assert!(b.pending_disconnect.is_some());
         }
 
         let mut a = generate_peer(true, 0);
         assert!(!a.is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(!torrent_state.piece_selector.bitfield_received(a.conn_id));
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; torrent_state.num_pieces());
         field.set(2, false);
         field.set(4, false);
-        a.handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
         // We are interestead since we do not have the pieces
         sent_and_marked_interested(&a);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(a.conn_id));
 
         for i in 0..torrent_state.num_pieces() {
@@ -928,20 +798,16 @@ fn bitfield_recv() {
 
         let mut b = generate_peer(true, 1);
         assert!(!b.is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(!torrent_state.piece_selector.bitfield_received(b.conn_id));
         let num_pieces = torrent_state.num_pieces();
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; num_pieces);
         field.set(2, false);
         field.set(4, false);
-        b.handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        b.handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
         // Still not interestead since no new pieces can be downloaded received
         assert!(!b.is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(b.conn_id));
 
         let mut c = generate_peer(true, 2);
@@ -950,15 +816,10 @@ fn bitfield_recv() {
         let num_pieces = torrent_state.num_pieces();
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 1; num_pieces);
         field.set(2, false);
-        c.handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        c.handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
         // New piece can be downloaded
         sent_and_marked_interested(&c);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(torrent_state.piece_selector.bitfield_received(c.conn_id));
     });
 }
@@ -966,14 +827,17 @@ fn bitfield_recv() {
 // TODO test we do not resend the not_interested message
 #[test]
 fn interest_is_updated_when_recv_piece() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
         assert!(!connections[key].is_interesting);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(
             !torrent_state
                 .piece_selector
@@ -983,15 +847,10 @@ fn interest_is_updated_when_recv_piece() {
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(2, true);
         field.set(4, true);
-        connections[key].handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
         // We are interestead since we do not have the pieces
         sent_and_marked_interested(&connections[key]);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         assert!(
             torrent_state
                 .piece_selector
@@ -1002,13 +861,13 @@ fn interest_is_updated_when_recv_piece() {
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index_a, key, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index_a, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         let index_b = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index_b, key, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index_b, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         assert_eq!(connections[key].inflight.len(), 4);
         assert!(connections[key].queued.is_empty());
@@ -1019,9 +878,7 @@ fn interest_is_updated_when_recv_piece() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -1030,13 +887,12 @@ fn interest_is_updated_when_recv_piece() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.update_torrent_status(&mut connections);
         assert!(connections[key].is_interesting);
         connections[key].handle_message(
@@ -1045,9 +901,7 @@ fn interest_is_updated_when_recv_piece() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key].handle_message(
@@ -1056,13 +910,12 @@ fn interest_is_updated_when_recv_piece() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.update_torrent_status(&mut connections);
         sent_and_marked_not_interested(&connections[key]);
     });
@@ -1070,9 +923,11 @@ fn interest_is_updated_when_recv_piece() {
 
 #[test]
 fn send_have_to_peers_when_piece_completes() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let b = generate_peer(true, 1);
         let c = generate_peer(true, 2);
@@ -1081,36 +936,26 @@ fn send_have_to_peers_when_piece_completes() {
         let key_b = connections.insert(b);
         connections.insert(c);
 
+        let (_, torrent_state) = state_ref.state().unwrap();
         let num_pieces = torrent_state.num_pieces();
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(2, true);
-        connections[key_a].handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_a].handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
         let mut field = bitvec::bitvec!(u8, bitvec::order::Msb0; 0; num_pieces);
         field.set(4, true);
-        connections[key_b].handle_message(
-            PeerMessage::Bitfield(field),
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_b].handle_message(PeerMessage::Bitfield(field), &mut state_ref, scope);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         let index_a = torrent_state
             .piece_selector
             .next_piece(key_a, &mut connections[key_a].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index_a, key_a, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index_a, key_a, &file_and_info.file_store);
         connections[key_a].append_and_fill(&mut subpieces);
         let index_b = torrent_state
             .piece_selector
             .next_piece(key_b, &mut connections[key_b].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index_b, key_b, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index_b, key_b, &file_and_info.file_store);
         connections[key_b].append_and_fill(&mut subpieces);
 
         connections[key_a].handle_message(
@@ -1119,9 +964,7 @@ fn send_have_to_peers_when_piece_completes() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key_a].handle_message(
@@ -1130,13 +973,12 @@ fn send_have_to_peers_when_piece_completes() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(150));
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.update_torrent_status(&mut connections);
         for (_, peer) in &mut connections {
             assert!(
@@ -1157,9 +999,7 @@ fn send_have_to_peers_when_piece_completes() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         connections[key_b].handle_message(
@@ -1168,13 +1008,12 @@ fn send_have_to_peers_when_piece_completes() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.update_torrent_status(&mut connections);
         for (_, peer) in &connections {
             assert!(
@@ -1192,17 +1031,13 @@ fn send_have_to_peers_when_piece_completes() {
 
 #[test]
 fn assume_intrest_when_request_recv() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         assert!(!a.peer_interested);
         a.handle_message(
             PeerMessage::Request {
@@ -1210,9 +1045,7 @@ fn assume_intrest_when_request_recv() {
                 begin: 0,
                 length: SUBPIECE_SIZE,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         // Assume the peer is interestead we recv a request from them
@@ -1222,26 +1055,23 @@ fn assume_intrest_when_request_recv() {
 
 #[test]
 fn piece_recv() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
-        connections[key].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
 
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         let prev_target_infligt = connections[key].target_inflight;
         assert_eq!(torrent_state.num_allocated(), 1);
         assert!(torrent_state.pieces[index as usize].is_some());
@@ -1259,11 +1089,10 @@ fn piece_recv() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(
             torrent_state.pieces[index as usize]
                 .as_ref()
@@ -1288,13 +1117,12 @@ fn piece_recv() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(connections[key].inflight.is_empty());
         assert_eq!(connections[key].target_inflight, prev_target_infligt + 2);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 0);
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
@@ -1308,26 +1136,23 @@ fn piece_recv() {
 
 #[test]
 fn handles_duplicate_piece_recv() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
 
-        connections[key].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         let prev_target_infligt = connections[key].target_inflight;
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         connections[key].handle_message(
             PeerMessage::Piece {
@@ -1335,9 +1160,7 @@ fn handles_duplicate_piece_recv() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert_eq!(connections[key].target_inflight, prev_target_infligt + 1);
@@ -1350,9 +1173,7 @@ fn handles_duplicate_piece_recv() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(connections[key].last_seen.elapsed() < Duration::from_millis(1));
@@ -1368,12 +1189,11 @@ fn handles_duplicate_piece_recv() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(connections[key].inflight.is_empty());
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 0);
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
@@ -1388,11 +1208,10 @@ fn handles_duplicate_piece_recv() {
                 begin: SUBPIECE_SIZE,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.piece_selector.total_allocated(), 0);
         assert!(!torrent_state.piece_selector.is_allocated(index as usize));
         assert!(torrent_state.piece_selector.has_completed(index as usize));
@@ -1402,18 +1221,15 @@ fn handles_duplicate_piece_recv() {
 
 #[test]
 fn invalid_piece() {
-    let (file_store, torrent_info) = setup_test();
-    rayon::scope(|scope| {
-        let mut torrent_state = TorrentState::new(&torrent_info);
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
-        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_store);
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_and_info.file_store);
         a.append_and_fill(&mut subpieces);
         assert!(a.pending_disconnect.is_none());
         a.handle_message(
@@ -1422,23 +1238,14 @@ fn invalid_piece() {
                 begin: 0,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(a.pending_disconnect.is_some());
-
-        let mut torrent_state = TorrentState::new(&torrent_info);
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
-        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_store);
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_and_info.file_store);
         a.append_and_fill(&mut subpieces);
         assert!(a.pending_disconnect.is_none());
         a.handle_message(
@@ -1447,23 +1254,15 @@ fn invalid_piece() {
                 begin: SUBPIECE_SIZE + 1,
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(a.pending_disconnect.is_some());
 
-        let mut torrent_state = TorrentState::new(&torrent_info);
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
-        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_store);
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_and_info.file_store);
         a.append_and_fill(&mut subpieces);
         assert!(a.pending_disconnect.is_none());
         a.handle_message(
@@ -1472,9 +1271,7 @@ fn invalid_piece() {
                 begin: 0,
                 data: vec![3; (SUBPIECE_SIZE + 1) as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(a.pending_disconnect.is_some());
@@ -1489,34 +1286,25 @@ fn invalid_piece() {
 // TODO timeout tests + Tests that ensure we handle redundant data
 #[test]
 fn snubbed_peer() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key = connections.insert(a);
-        connections[key].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         // Hack to prevent this from requesting things
         connections[key].is_interesting = false;
-        connections[key].handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key].handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         connections[key].is_interesting = true;
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(key, &mut connections[key].endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index, key, &file_store);
+        let mut subpieces = torrent_state.allocate_piece(index, key, &file_and_info.file_store);
         connections[key].append_and_fill(&mut subpieces);
         assert_eq!(connections[key].inflight.len(), 2);
         assert!(connections[key].queued.is_empty());
@@ -1528,9 +1316,7 @@ fn snubbed_peer() {
                 // TODO: THIS MIGHT BE INCORRECT
                 data: vec![3; SUBPIECE_SIZE as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(connections[key].last_received_subpiece.is_some());
@@ -1544,12 +1330,12 @@ fn snubbed_peer() {
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
         assert!(!connections[key].slow_start);
         assert!(connections[key].snubbed);
         assert!(connections[key].inflight[0].timed_out);
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert!(!torrent_state.piece_selector.is_allocated(index as usize));
         assert_eq!(torrent_state.num_allocated(), 1);
         assert_eq!(connections[key].target_inflight, 1);
@@ -1561,17 +1347,14 @@ fn snubbed_peer() {
                 begin: inflight.offset,
                 data: vec![3; inflight.size as usize].into(),
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         tick(
             &Duration::from_secs(1),
             &mut connections,
             &Default::default(),
-            &file_store,
-            &mut torrent_state,
+            &mut state_ref,
         );
         assert!(!connections[key].snubbed);
         assert!(connections[key].target_inflight > 1);
@@ -1580,32 +1363,24 @@ fn snubbed_peer() {
 
 #[test]
 fn reject_request_requests_new() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         // Hack to prevent this from requesting things
         a.is_interesting = false;
-        a.handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         a.is_interesting = true;
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         let index = torrent_state
             .piece_selector
             .next_piece(a.conn_id, &mut a.endgame)
             .unwrap();
-        let mut subpieces = torrent_state.allocate_piece(index, a.conn_id, &file_store);
+        let mut subpieces =
+            torrent_state.allocate_piece(index, a.conn_id, &file_and_info.file_store);
         a.append_and_fill(&mut subpieces);
         assert_eq!(a.inflight.len(), 2);
         assert!(a.inflight.contains(&Subpiece {
@@ -1621,9 +1396,7 @@ fn reject_request_requests_new() {
                 begin: 0,
                 length: SUBPIECE_SIZE,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(!a.inflight.contains(&Subpiece {
@@ -1633,6 +1406,7 @@ fn reject_request_requests_new() {
             timed_out: false,
         }));
         // New piece started
+        let (_, torrent_state) = state_ref.state().unwrap();
         assert_eq!(torrent_state.num_allocated(), 1);
         assert!(!torrent_state.piece_selector.is_allocated(index as usize));
         // Last piece only have one subpiece
@@ -1646,9 +1420,11 @@ fn reject_request_requests_new() {
 
 #[test]
 fn invalid_reject_request() {
-    let (file_store, torrent_info) = setup_test();
-    rayon::scope(|scope| {
-        let mut torrent_state = TorrentState::new(&torrent_info);
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let mut b = generate_peer(false, 0);
         b.handle_message(
             PeerMessage::RejectRequest {
@@ -1656,34 +1432,21 @@ fn invalid_reject_request() {
                 begin: 0,
                 length: SUBPIECE_SIZE,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert!(matches!(
             b.pending_disconnect,
             Some(DisconnectReason::ProtocolError(_))
         ));
-        let mut a = generate_peer(true, 0);
-        a.handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        let mut a = generate_peer(true, 1);
+        a.handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
         // Hack to prevent this from requesting things
         a.is_interesting = false;
-        a.handle_message(
-            PeerMessage::Unchoke,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        a.handle_message(PeerMessage::Unchoke, &mut state_ref, scope);
         a.is_interesting = true;
-        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_store);
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
+        let mut subpieces = torrent_state.allocate_piece(2, a.conn_id, &file_and_info.file_store);
         a.append_and_fill(&mut subpieces);
         assert!(a.pending_disconnect.is_none());
         a.handle_message(
@@ -1692,24 +1455,22 @@ fn invalid_reject_request() {
                 begin: 0,
                 length: SUBPIECE_SIZE,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
+        assert!(a.pending_disconnect.is_some());
+        a.pending_disconnect = None;
         a.handle_message(
             PeerMessage::RejectRequest {
                 index: 2,
                 begin: SUBPIECE_SIZE + 1,
                 length: SUBPIECE_SIZE,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
-        assert!(a.pending_disconnect.is_none());
-        // Both are invalid and ignored
+        assert!(a.pending_disconnect.is_some());
+        a.pending_disconnect = None;
         assert_eq!(a.inflight.len(), 2);
         a.handle_message(
             PeerMessage::RejectRequest {
@@ -1717,58 +1478,50 @@ fn invalid_reject_request() {
                 begin: 0,
                 length: SUBPIECE_SIZE + 1,
             },
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
+            &mut state_ref,
             scope,
         );
         assert_eq!(a.inflight.len(), 2);
-        assert!(a.pending_disconnect.is_none());
+        assert!(a.pending_disconnect.is_some());
     });
 }
 
 #[test]
 fn endgame_mode() {
-    let (file_store, torrent_info) = setup_test();
-    let mut torrent_state = TorrentState::new(&torrent_info);
-    rayon::scope(|scope| {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
         let a = generate_peer(true, 0);
         let mut connections = Slab::new();
         let key_a = connections.insert(a);
 
-        connections[key_a].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_a].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
 
         let b = generate_peer(true, 1);
         let key_b = connections.insert(b);
 
-        connections[key_b].handle_message(
-            PeerMessage::HaveAll,
-            &mut torrent_state,
-            &file_store,
-            &torrent_info,
-            scope,
-        );
+        connections[key_b].handle_message(PeerMessage::HaveAll, &mut state_ref, scope);
 
         // it has a annyoing content so take it out of equation
+        let (file_and_info, torrent_state) = state_ref.state().unwrap();
         torrent_state.piece_selector.mark_complete(0);
         // same
         torrent_state.piece_selector.mark_complete(8);
 
         // Set up so that half of the pieces have been requested and that a part of those have been
         // completed
-        for i in 0..torrent_state.num_pieces() / 2 {
+        let num_pieces_half = torrent_state.num_pieces() / 2;
+        for i in 0..num_pieces_half {
+            let (_, torrent_state) = state_ref.state().unwrap();
             let index = torrent_state
                 .piece_selector
                 .next_piece(key_a, &mut connections[key_a].endgame)
                 .unwrap();
             assert!(!connections[key_a].endgame);
-            let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_store);
+            let mut subpieces =
+                torrent_state.allocate_piece(index, key_a, &file_and_info.file_store);
             connections[key_a].append_and_fill(&mut subpieces);
             if i % 2 == 0 {
                 connections[key_a].handle_message(
@@ -1777,9 +1530,7 @@ fn endgame_mode() {
                         begin: 0,
                         data: vec![3; SUBPIECE_SIZE as usize].into(),
                     },
-                    &mut torrent_state,
-                    &file_store,
-                    &torrent_info,
+                    &mut state_ref,
                     scope,
                 );
                 connections[key_a].handle_message(
@@ -1788,32 +1539,36 @@ fn endgame_mode() {
                         begin: SUBPIECE_SIZE,
                         data: vec![3; SUBPIECE_SIZE as usize].into(),
                     },
-                    &mut torrent_state,
-                    &file_store,
-                    &torrent_info,
+                    &mut state_ref,
                     scope,
                 );
             }
         }
         // To ensure we do not miss the completion event
         std::thread::sleep(Duration::from_millis(100));
+        let (_, torrent_state) = state_ref.state().unwrap();
         torrent_state.update_torrent_status(&mut connections);
         assert!(!connections[key_a].endgame);
         assert!(!connections[key_b].endgame);
+        let (_, torrent_state) = state_ref.state().unwrap();
         let remaining = torrent_state.num_pieces()
             - torrent_state.piece_selector.total_allocated()
             - torrent_state.piece_selector.total_completed();
         // request the rest from the other peer so that everything has been allocated
         for _ in 0..remaining {
+            let (_, torrent_state) = state_ref.state().unwrap();
             let index = torrent_state
                 .piece_selector
                 .next_piece(key_b, &mut connections[key_b].endgame)
                 .unwrap();
             assert!(!connections[key_b].endgame);
-            let mut subpieces = torrent_state.allocate_piece(index, key_b, &file_store);
+            let (file_and_info, torrent_state) = state_ref.state().unwrap();
+            let mut subpieces =
+                torrent_state.allocate_piece(index, key_b, &file_and_info.file_store);
             connections[key_b].append_and_fill(&mut subpieces);
         }
         for _ in 0..remaining {
+            let (_, torrent_state) = state_ref.state().unwrap();
             let index = torrent_state
                 .piece_selector
                 .next_piece(key_a, &mut connections[key_a].endgame)
@@ -1832,8 +1587,666 @@ fn endgame_mode() {
                     .iter()
                     .any(|piece| piece.index == index)
             );
-            let mut subpieces = torrent_state.allocate_piece(index, key_a, &file_store);
+            let (file_and_info, torrent_state) = state_ref.state().unwrap();
+            let mut subpieces =
+                torrent_state.allocate_piece(index, key_a, &file_and_info.file_store);
             connections[key_a].append_and_fill(&mut subpieces);
         }
+    });
+}
+
+// BEP 10 and BEP 9 Tests
+
+#[test]
+fn extension_protocol_handshake() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        // Create peer with extension protocol support
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+        assert!(a.extensions.is_empty());
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+
+        // Simulate receiving extension handshake with ut_metadata support
+        let handshake_data = format!(
+            "d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}e1:v14:TestClient 1.0ee"
+        );
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Should have created metadata extension
+        assert!(!a.extensions.is_empty());
+        assert!(a.extensions.contains_key(&1)); // ut_metadata extension ID
+        assert_eq!(a.max_queue_size, 200); // Default value since no reqq specified
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn extension_handshake_with_reqq() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+
+        // Handshake with custom queue size
+        let handshake_data =
+            format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}e4:reqqi100eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert_eq!(a.max_queue_size, 100);
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn extension_handshake_malformed() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let invalid_data = b"invalid bencoded data";
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: invalid_data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert!(a.pending_disconnect.is_some());
+    });
+}
+
+#[test]
+fn extension_handshake_missing_m_field() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        // Missing 'm' field
+        let handshake_data = br#"d1:v14:TestClient 1.0ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert!(a.pending_disconnect.is_some());
+        assert!(matches!(
+            a.pending_disconnect,
+            Some(DisconnectReason::ProtocolError(_))
+        ));
+    });
+}
+
+#[test]
+fn metadata_extension_request_message() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+        // First send handshake to set up extension
+        let handshake_data = format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Clear any messages from handshake
+        a.outgoing_msgs_buffer.clear();
+
+        // Send metadata request (message type 0, piece 0)
+        let request_data = br#"d8:msg_typei0e5:piecei0ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1, // ut_metadata extension ID
+                data: request_data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+        let metadata = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode();
+
+        assert!(!a.outgoing_msgs_buffer.is_empty());
+        let response = &a.outgoing_msgs_buffer[0];
+        if let PeerMessage::Extended { id, data } = &response.message {
+            let mut de = Deserializer::from_slice(&data[..]);
+            let message: MetadataMessage = <MetadataMessage>::deserialize(&mut de).unwrap();
+            assert_eq!(
+                message,
+                MetadataMessage {
+                    msg_type: 1, // DATA
+                    piece: 0,
+                    total_size: Some(metadata.len() as i32)
+                }
+            );
+            let metadata_piece = &data[de.byte_offset()..];
+            assert_eq!(metadata_piece, &metadata);
+            assert_eq!(*id, 3); // The peer should use the ID we told it to use (3)
+        } else {
+            panic!("Expected Extended message");
+        }
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn metadata_extension_data_message() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+        let handshake_data = format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        let mut data_msg = format!("d8:msg_typei1e5:piecei0e10:total_sizei{expected_size}ee")
+            .as_bytes()
+            .to_vec();
+        // Append some dummy metadata
+        data_msg.extend_from_slice(&vec![0u8; expected_size as usize]);
+
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: data_msg.into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn metadata_extension_reject_message() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+        // Set up extension
+        let handshake_data = format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        let reject_data = br#"d8:msg_typei2e5:piecei0ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: reject_data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn metadata_extension_invalid_message_type() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+        // Set up extension
+        let handshake_data = format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Send invalid message type (message type 99)
+        let invalid_data = br#"d8:msg_typei99e5:piecei0ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: invalid_data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Should not disconnect for unknown message types (as per BEP 9)
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn extension_message_unknown_id() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        // Send message with unknown extension ID (no handshake first)
+        let data = br#"d8:msg_typei0e5:piecei0ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 99, // Unknown extension ID
+                data: data.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Should not disconnect for unknown extension IDs
+        assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn metadata_extension_piece_bounds_validation() {
+    let mut download_state = setup_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+
+        let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+
+        // Set up extension with known metadata size
+        let handshake_data = format!("d1:md11:ut_metadatai3ee13:metadata_sizei{expected_size}eee");
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Send request for negative piece index
+        let invalid_request = br#"d8:msg_typei0e5:piecei-1ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: invalid_request.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        // Should handle gracefully (implementation specific)
+        // This test ensures the implementation doesn't panic
+
+        // Send request for very large piece index
+        let large_request = br#"d8:msg_typei0e5:piecei999999ee"#;
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: large_request.to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+
+        assert!(a.pending_disconnect.is_some());
+    });
+}
+
+#[test]
+fn extension_handshake_generates_correct_message() {
+    use crate::peer_comm::extended_protocol::extension_handshake_msg;
+    let mut download_state = setup_test();
+
+    let mut state_ref = download_state.as_ref();
+    let handshake = extension_handshake_msg(&mut state_ref);
+
+    if let PeerMessage::Extended { id, data } = handshake {
+        assert_eq!(id, 0); // Handshake uses ID 0
+
+         let expected_size = state_ref
+            .state()
+            .unwrap()
+            .0
+            .metadata
+            .construct_info()
+            .encode()
+            .len();
+        // Parse the bencoded data to verify structure
+        let parsed: bt_bencode::Value = bt_bencode::from_slice(&data).unwrap();
+        let dict = parsed.as_dict().unwrap();
+        
+        // Should contain 'm' field with ut_metadata
+        assert!(dict.contains_key("m".as_bytes()));
+        let m = dict.get("m".as_bytes()).unwrap().as_dict().unwrap();
+        assert!(m.contains_key("ut_metadata".as_bytes()));
+        
+        assert!(dict.contains_key("v".as_bytes()));
+        
+        assert_eq!(
+            dict.get("reqq".as_bytes()).unwrap().as_u64().unwrap(),
+            MAX_OUTSTANDING_REQUESTS
+        );
+        assert_eq!(
+            dict.get("metadata_size".as_bytes())
+                .unwrap()
+                .as_u64()
+                .unwrap(),
+            expected_size as u64
+        );
+    } else {
+        panic!("Expected Extended message");
+    }
+}
+
+
+#[test] 
+fn metadata_download_single_piece() {
+    let (mut download_state, torrent_info) = setup_uninitialized_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+        
+        // Verify state is not initialized
+        assert!(!state_ref.is_initialzied());
+        assert!(state_ref.state().is_none());
+        
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+        
+        // Get the actual metadata that should be downloaded
+        let metadata_bytes = torrent_info.construct_info().encode();
+        
+        // Set up extension handshake - peer tells us they have metadata of this size
+        let handshake_data = format!(
+            "d1:md11:ut_metadatai3ee13:metadata_sizei{}ee",
+            metadata_bytes.len()
+        );
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+        
+        // Should have created metadata extension and sent requests
+        assert!(!a.extensions.is_empty());
+        assert!(a.extensions.contains_key(&1)); // ut_metadata extension ID
+        assert!(!a.outgoing_msgs_buffer.is_empty()); // Should have sent metadata requests
+        
+        // Clear outgoing messages 
+        a.outgoing_msgs_buffer.clear();
+        
+        // Since metadata is small (< 16KiB), it should be a single piece
+        let mut data_msg = format!("d8:msg_typei1e5:piecei0e10:total_sizei{}ee", metadata_bytes.len())
+            .as_bytes()
+            .to_vec();
+        data_msg.extend_from_slice(&metadata_bytes);
+        
+                 // Send the metadata as a DATA message
+         a.handle_message(
+             PeerMessage::Extended {
+                 id: 1, // ut_metadata extension ID from our side
+                 data: data_msg.into(),
+             },
+             &mut state_ref,
+             scope,
+         );
+         
+         // Check if there was a hash mismatch or other error
+         if let Some(reason) = &a.pending_disconnect {
+             panic!("Peer got disconnected: {:?}", reason);
+         }
+         
+         // State should now be initialized with the downloaded metadata
+         if !state_ref.is_initialzied() {
+             // Let's check what went wrong - maybe the metadata size doesn't match?
+             panic!("State was not initialized after receiving metadata. Metadata size: {}, Expected info hash: {:?}", 
+                    metadata_bytes.len(), 
+                    state_ref.info_hash());
+         }
+         
+         let (file_and_meta, torrent_state) = state_ref.state().unwrap();
+         
+         // Verify the metadata matches what we sent
+         assert_eq!(file_and_meta.metadata.construct_info().encode(), metadata_bytes);
+         assert_eq!(torrent_state.num_pieces(), torrent_info.pieces.len());
+         
+         assert!(a.pending_disconnect.is_none());
+    });
+}
+
+#[test]
+fn metadata_download_multiple_pieces() {
+    // Use large metadata to test real multi-piece download
+    let (mut download_state, torrent_info) = setup_uninitialized_test_with_metadata_size(true);
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+        
+        // Verify state is not initialized
+        assert!(!state_ref.is_initialzied());
+        
+        let mut a = generate_peer(true, 0);
+        a.extended_extension = true;
+        
+        // Get the actual metadata - this should now be large enough to require multiple pieces
+        let metadata_bytes = torrent_info.construct_info().encode();
+        println!("Metadata size: {} bytes (should be > {} for multi-piece)", 
+                 metadata_bytes.len(), SUBPIECE_SIZE);
+        
+        // Verify we have large enough metadata to test multi-piece download
+        assert!(metadata_bytes.len() > SUBPIECE_SIZE as usize, 
+                "Metadata should be larger than {} bytes to test multi-piece download", SUBPIECE_SIZE);
+        
+        // Set up extension handshake
+        let handshake_data = format!(
+            "d1:md11:ut_metadatai3ee13:metadata_sizei{}ee",
+            metadata_bytes.len()
+        );
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 0,
+                data: handshake_data.as_bytes().to_vec().into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+        
+        // Should have requested multiple pieces
+        assert!(!a.outgoing_msgs_buffer.is_empty());
+        a.outgoing_msgs_buffer.clear();
+        
+        // Calculate the number of pieces needed
+        let piece_size = SUBPIECE_SIZE as usize;
+        let num_pieces = (metadata_bytes.len() + piece_size - 1) / piece_size;
+        println!("Will need {} pieces to download {} bytes of metadata", num_pieces, metadata_bytes.len());
+        
+        // Send all pieces except the last one
+        for piece_idx in 0..(num_pieces - 1) {
+            let start_offset = piece_idx * piece_size;
+            let end_offset = start_offset + piece_size;
+            
+            let mut data_msg = format!("d8:msg_typei1e5:piecei{}e10:total_sizei{}ee", 
+                                      piece_idx, metadata_bytes.len())
+                .as_bytes()
+                .to_vec();
+            data_msg.extend_from_slice(&metadata_bytes[start_offset..end_offset]);
+            
+            a.handle_message(
+                PeerMessage::Extended {
+                    id: 1,
+                    data: data_msg.into(),
+                },
+                &mut state_ref,
+                scope,
+            );
+            
+            // Should still not be initialized, but may request next piece
+            assert!(!state_ref.is_initialzied());
+            a.outgoing_msgs_buffer.clear();
+        }
+        
+        // Send the final piece
+        let final_piece_idx = num_pieces - 1;
+        let start_offset = final_piece_idx * piece_size;
+        
+        let mut data_msg = format!("d8:msg_typei1e5:piecei{}e10:total_sizei{}ee", 
+                                  final_piece_idx, metadata_bytes.len())
+            .as_bytes()
+            .to_vec();
+        data_msg.extend_from_slice(&metadata_bytes[start_offset..]);
+        
+        a.handle_message(
+            PeerMessage::Extended {
+                id: 1,
+                data: data_msg.into(),
+            },
+            &mut state_ref,
+            scope,
+        );
+        
+        // Now the state should be initialized with the complete metadata
+        if let Some(reason) = &a.pending_disconnect {
+            panic!("Peer got disconnected: {:?}", reason);
+        }
+        
+        assert!(state_ref.is_initialzied(), "State should be initialized after receiving all metadata pieces");
+        let (file_and_meta, torrent_state) = state_ref.state().unwrap();
+        
+        // Verify the metadata matches what we sent
+        assert_eq!(file_and_meta.metadata.construct_info().encode(), metadata_bytes);
+        assert_eq!(torrent_state.num_pieces(), torrent_info.pieces.len());
+        
+        assert!(a.pending_disconnect.is_none());
     });
 }


### PR DESCRIPTION
This is a huge PR since the supporting the late metadata initialization required modification how state was handled through out the event loop. It was hard to split up so it is what it is. 

Support for both BEP 9 and 10 is implemented in this which means that magnet links can not be supported! It also means that the max size of the target_inflight is dynamically modified based off what the peer reports as `reqq` value