### PR TITLE
Use jemalloc and fix LinkTimeout UB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2256,7 @@ dependencies = [
  "mainline",
  "metrics-exporter-prometheus 0.16.2",
  "parking_lot",
+ "tikv-jemallocator",
  "vortex-bittorrent",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sha1 = "0.10"
 
 [profile.release]
 overflow-checks = true
-debug-assertions = true
+# debug = true 
 lto = true
 
 [profile.release.package."*"]

--- a/bittorrent/src/io_utils.rs
+++ b/bittorrent/src/io_utils.rs
@@ -186,7 +186,7 @@ pub fn recv<Q: SubmissionQueue>(
     user_data: UserData,
     fd: RawFd,
     bgid: Bgid,
-    timeout_secs: u64,
+    timeout: &Timespec,
 ) {
     log::debug!("Starting recv");
     let read_op = opcode::Recv::new(types::Fd(fd), null_mut(), 0)
@@ -195,9 +195,8 @@ pub fn recv<Q: SubmissionQueue>(
         .user_data(user_data.as_u64())
         .flags(io_uring::squeue::Flags::BUFFER_SELECT | io_uring::squeue::Flags::IO_LINK);
 
-    let timeout = Timespec::new().sec(timeout_secs);
     let user_data = UserData::new(user_data.event_idx as _, None);
-    let timeout_op = opcode::LinkTimeout::new(&timeout)
+    let timeout_op = opcode::LinkTimeout::new(timeout)
         .build()
         .user_data(user_data.as_u64());
     // If the queue doesn't fit both events they need

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ lava_torrent = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
 vortex-bittorrent = { path = "../bittorrent" }
+tikv-jemallocator = "0.5"
 # NOTE: The 5.4.0 version doesn't seem to have been posted to GIT so do not update unless the code is public
 mainline = { version = "=5.3.1", default-features = false, features = ["node"]}
 metrics-exporter-prometheus = "0.16"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,11 @@ use mainline::{Dht, Id};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use vortex_bittorrent::{Command, State, Torrent, generate_peer_id};
 
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 pub fn decode_info_hash_hex(s: &str) -> [u8; 20] {
     (0..s.len())
         .step_by(2)


### PR DESCRIPTION
Seems like all link timeout timespec arguments needs to be constants. Before this change I got "Invalid argument" on the recv operations when running release builds indicating UB.

I've also switched out the allocator to jemalloc since that gave better stats when measured in bytehound.  Memory usage, less "leaked" memory (not too concerned about that atm since most of it seems to be static stuff like metrics etc) were all better.  I expect better perf as well even though I  didn't measure that directly.  The reduction in anonymous memory was from about 80mb to around 60mb so pretty significant. The binary size diff was from around 9.5mb to 10.8mb so worth it