### PR TITLE
Add TorrentEvents to make it easier for clients to read updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,12 +807,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1934,6 +1959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2257,7 @@ dependencies = [
  "bt_bencode",
  "bytes",
  "env_logger",
+ "heapless",
  "io-uring 0.7.5",
  "lava_torrent",
  "libc",
@@ -2251,6 +2283,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "heapless",
  "lava_torrent",
  "log",
  "mainline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2291,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "clap",
+ "crossbeam-channel",
  "env_logger",
  "heapless",
  "lava_torrent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.11"
 lava_torrent = "0.11"
 thiserror = "2"
 sha1 = "0.10"
+heapless = "0.8"
 
 [profile.release]
 overflow-checks = true

--- a/bittorrent/Cargo.toml
+++ b/bittorrent/Cargo.toml
@@ -22,6 +22,7 @@ lava_torrent = { workspace = true }
 thiserror = { workspace = true }
 sha1 = { workspace = true }
 smallvec= { version = "2.0.0-alpha.10" , features = ["std"]}
+heapless = { workspace = true }
 rayon = "1"
 metrics = "0.24"
 bt_bencode = "0.8.2"

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -790,14 +790,16 @@ fn report_tick_metrics(
     let mut pieces_completed = 0;
     let mut pieces_allocated = 0;
     if let Some((_, torrent_state)) = state.state() {
+        let total_completed = torrent_state.piece_selector.total_completed();
         let counter = metrics::counter!("pieces_completed");
-        counter.absolute(torrent_state.piece_selector.total_completed() as u64);
+        counter.absolute(total_completed as u64);
+        let total_allocated = torrent_state.piece_selector.total_allocated();
         let gauge = metrics::gauge!("pieces_allocated");
-        gauge.set(torrent_state.piece_selector.total_allocated() as u32);
+        gauge.set(total_allocated as u32);
         let gauge = metrics::gauge!("num_unchoked");
         gauge.set(torrent_state.num_unchoked);
-        pieces_completed = pieces_completed;
-        pieces_allocated = pieces_allocated;
+        pieces_completed = total_completed;
+        pieces_allocated = total_allocated;
     }
     let gauge = metrics::gauge!("num_connections");
     gauge.set(connections.len() as u32);

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -6,7 +6,6 @@ use std::{
     os::fd::AsRawFd,
     path::{Path, PathBuf},
     sync::mpsc::{Receiver, Sender},
-    time::Duration,
 };
 
 use event_loop::{EventLoop, EventType};

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -2,14 +2,16 @@ use std::{
     cell::OnceCell,
     collections::VecDeque,
     io::{self},
-    net::TcpListener,
+    net::{SocketAddrV4, TcpListener},
     os::fd::AsRawFd,
     path::{Path, PathBuf},
     sync::mpsc::{Receiver, Sender},
+    time::Duration,
 };
 
 use event_loop::{EventLoop, EventType};
 use file_store::FileStore;
+use heapless::spsc::{Consumer, Producer};
 use io_uring::{
     IoUring, opcode,
     types::{self},
@@ -32,7 +34,6 @@ use peer_comm::{peer_connection::PeerConnection, *};
 #[cfg(feature = "fuzzing")]
 pub use peer_protocol::*;
 
-pub use event_loop::Command;
 pub use peer_protocol::PeerId;
 pub use peer_protocol::generate_peer_id;
 
@@ -54,7 +55,11 @@ impl Torrent {
         Self { our_id, state }
     }
 
-    pub fn start(&mut self, command_rc: Receiver<Command>) -> Result<(), Error> {
+    pub fn start(
+        &mut self,
+        event_tx: Producer<TorrentEvent, 512>,
+        command_rc: Consumer<Command, 64>,
+    ) -> Result<(), Error> {
         // check ulimit
         let mut ring: IoUring = IoUring::builder()
             .setup_single_issuer()
@@ -78,9 +83,37 @@ impl Torrent {
             ring.submission().push(&accept_op).unwrap();
         }
         ring.submission().sync();
-        let mut event_loop = EventLoop::new(self.our_id, events, command_rc);
-        event_loop.run(ring, &mut self.state)
+        let mut event_loop = EventLoop::new(self.our_id, events);
+        event_loop.run(ring, &mut self.state, event_tx, command_rc)
     }
+}
+
+/// Commands that can be sent to the event loop through the command channel
+#[derive(Debug)]
+pub enum Command {
+    /// Connect to peers at the given address
+    /// already connected peers will be filtered out
+    ConnectToPeers(Vec<SocketAddrV4>),
+    /// Stop the event loop gracefully
+    Stop,
+}
+
+/// Events from the inprogress torrent
+#[derive(Debug)]
+pub enum TorrentEvent {
+    TorrentComplete,
+    MetadataComplete(Box<lava_torrent::torrent::v1::Torrent>),
+    PeerMetrics {
+        conn_id: usize,
+        throuhgput: u64,
+        endgame: bool,
+        snubbed: bool,
+    },
+    TorrentMetrics {
+        pieces_completed: usize,
+        pieces_allocated: usize,
+        num_connections: usize,
+    },
 }
 
 pub struct InitializedState {

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -6,14 +6,15 @@ use serde::Deserialize;
 use slab::Slab;
 
 use crate::{
-    event_loop::{tick, MAX_OUTSTANDING_REQUESTS},
+    TorrentEvent,
+    event_loop::{MAX_OUTSTANDING_REQUESTS, tick},
     peer_comm::{extended_protocol::MetadataMessage, peer_connection::DisconnectReason},
     peer_connection::OutgoingMsg,
-    piece_selector::{Subpiece, SUBPIECE_SIZE},
+    piece_selector::{SUBPIECE_SIZE, Subpiece},
     test_utils::{
         generate_peer, setup_test, setup_uninitialized_test,
         setup_uninitialized_test_with_metadata_size,
-    }, TorrentEvent,
+    },
 };
 
 use super::{peer_connection::PeerConnection, peer_protocol::PeerMessage};

--- a/bittorrent/tests/basic.rs
+++ b/bittorrent/tests/basic.rs
@@ -54,19 +54,19 @@ fn basic_seeded_download() {
                         let _ = command_tx.enqueue(Command::Stop);
                         break 'outer;
                     }
-                    TorrentEvent::MetadataComplete(torrent) => {
+                    TorrentEvent::MetadataComplete(_torrent) => {
                         log::info!("METADATA COMPLETE");
                     }
                     TorrentEvent::PeerMetrics {
-                        conn_id,
-                        throuhgput,
-                        endgame,
-                        snubbed,
+                        conn_id: _,
+                        throuhgput: _,
+                        endgame: _,
+                        snubbed: _,
                     } => {}
                     TorrentEvent::TorrentMetrics {
-                        pieces_completed,
-                        pieces_allocated,
-                        num_connections,
+                        pieces_completed: _,
+                        pieces_allocated: _,
+                        num_connections: _,
                     } => {}
                 }
             }

--- a/bittorrent/tests/basic.rs
+++ b/bittorrent/tests/basic.rs
@@ -1,7 +1,7 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use metrics_exporter_prometheus::PrometheusBuilder;
-use vortex_bittorrent::{Command, State, Torrent, generate_peer_id};
+use vortex_bittorrent::{Command, State, Torrent, TorrentEvent, generate_peer_id};
 
 #[test]
 fn basic_seeded_download() {
@@ -20,25 +20,56 @@ fn basic_seeded_download() {
     );
 
     let download_time = Instant::now();
-    let (tx, rc) = std::sync::mpsc::channel();
+    let mut command_q = heapless::spsc::Queue::new();
+    let mut event_q = heapless::spsc::Queue::new();
 
-    tx.send(Command::ConnectToPeers(vec![
-        "127.0.0.1:51413".parse().unwrap(),
-    ]))
-    .unwrap();
+    let (mut command_tx, command_rc) = command_q.split();
+    let (event_tx, mut event_rc) = event_q.split();
 
-    // Spawn a thread to send Stop command after a timeout
-    let tx_clone = tx.clone();
-    std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_secs(60));
-        // Send stop command if download takes too long
-        let _ = tx_clone.send(Command::Stop);
+    command_tx
+        .enqueue(Command::ConnectToPeers(vec![
+            "127.0.0.1:51413".parse().unwrap(),
+        ]))
+        .unwrap();
+
+    std::thread::scope(move |s| {
+        // Spawn a thread to send Stop command after a timeout
+        s.spawn(move || {
+            torrent.start(event_tx, command_rc).unwrap();
+        });
+        'outer: loop {
+            if download_time.elapsed() >= Duration::from_secs(60) {
+                // Should never take this long
+                panic!("Download is too slow");
+            }
+            while let Some(event) = event_rc.dequeue() {
+                match event {
+                    TorrentEvent::TorrentComplete => {
+                        let elapsed = download_time.elapsed();
+                        log::info!("Download complete in: {}s", elapsed.as_secs());
+                        let expected = std::fs::read("../assets/test-file-1").unwrap();
+                        let actual =
+                            std::fs::read("../downloaded/test-file-1/test-file-1").unwrap();
+                        assert_eq!(actual, expected);
+                        let _ = command_tx.enqueue(Command::Stop);
+                        break 'outer;
+                    }
+                    TorrentEvent::MetadataComplete(torrent) => {
+                        log::info!("METADATA COMPLETE");
+                    }
+                    TorrentEvent::PeerMetrics {
+                        conn_id,
+                        throuhgput,
+                        endgame,
+                        snubbed,
+                    } => {}
+                    TorrentEvent::TorrentMetrics {
+                        pieces_completed,
+                        pieces_allocated,
+                        num_connections,
+                    } => {}
+                }
+            }
+        }
     });
-
-    torrent.start(rc).unwrap();
-    let elapsed = download_time.elapsed();
-    log::info!("Download complete in: {}s", elapsed.as_secs());
-    let expected = std::fs::read("../assets/test-file-1").unwrap();
-    let actual = std::fs::read("../downloaded/test-file-1/test-file-1").unwrap();
-    assert_eq!(actual, expected);
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,4 +22,5 @@ tikv-jemallocator = "0.5"
 mainline = { version = "=5.3.1", default-features = false, features = ["node"]}
 metrics-exporter-prometheus = "0.16"
 clap = { version = "4.5.39", features = ["derive"] }
+crossbeam-channel = "0.5.15"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ lava_torrent = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
 vortex-bittorrent = { path = "../bittorrent" }
+heapless = { workspace = true }
 tikv-jemallocator = "0.5"
 # NOTE: The 5.4.0 version doesn't seem to have been posted to GIT so do not update unless the code is public
 mainline = { version = "=5.3.1", default-features = false, features = ["node"]}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -120,12 +120,10 @@ fn main() {
                 println!("DHT query");
                 // query
                 let all_peers = dht_client.get_peers(info_hash_id);
+                let mut cmd_tx = cmd_tx_clone.lock();
                 for peers in all_peers {
                     log::info!("Got {} peers", peers.len());
-                    cmd_tx_clone
-                        .lock()
-                        .enqueue(Command::ConnectToPeers(peers))
-                        .unwrap();
+                    cmd_tx.enqueue(Command::ConnectToPeers(peers)).unwrap();
                 }
             };
 


### PR DESCRIPTION
- Uses the spsc queue from heapless since that's simpler and better suited for an eventloop. If the client requires multiple threads to send commands (like in the cli) it's up to the client to deal with synchronization. In this case a mutex is perfectly fine since it will be extremely little contention
- Prevent the event loop to shutdown as soon as the torrent completes