### PR TITLE
Connection shutdown cleanup 1/2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 bytes = "1.10"
 anyhow = "1.0"
 ahash = "0.8"
-log = "0.4"
+log = { version = "0.4", features = ["release_max_level_info"]}
 parking_lot = "0.12"
 rand = "0.9"
 env_logger = "0.11"

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -481,7 +481,7 @@ impl<'scope, 'state: 'scope> EventLoop {
                         for connection in self.connections.drain() {
                             log::info!(
                                 "[{}] Closing connection to peer: {}",
-                                connection.socket.peer_addr().unwrap().as_socket().unwrap()
+                                connection.socket.peer_addr().unwrap().as_socket().unwrap(),
                                 connection.peer_id,
                             );
                             io_utils::close_socket(sq, connection.socket, &mut self.events);
@@ -744,8 +744,9 @@ impl<'scope, 'state: 'scope> EventLoop {
                 if len == 0 {
                     let mut connection = self.connections.remove(connection_idx);
                     log::debug!(
-                        "[PeerId: {}] No more data, graceful shutdown complete",
-                        connection.peer_id
+                        "[PeerId: {}] No more data, graceful shutdown complete {}",
+                        connection.peer_id,
+                        connection.socket.peer_addr().unwrap().as_socket().unwrap()
                     );
                     self.events.remove(io_event.user_data.event_idx as _);
                     // Consider moving to func

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -130,8 +130,6 @@ pub enum DisconnectReason {
     ProtocolError(&'static str),
     #[error("Invalid message received")]
     InvalidMessage,
-    #[error("Event loop is shutting down")]
-    ShuttingDown,
 }
 
 pub struct PeerConnection {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> io::Result<()> {
         OpenOptions::new()
             .create(true)
             .append(true)
-            .open("vortext.log")?,
+            .open("vortex.log")?,
     );
     env_logger::builder()
         .target(env_logger::Target::Pipe(target))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs::OpenOptions,
     io,
     path::PathBuf,
     sync::Arc,
@@ -117,8 +118,16 @@ struct Cli {
 }
 
 fn main() -> io::Result<()> {
-    let mut log_builder = env_logger::builder();
-    log_builder.filter_level(log::LevelFilter::Off).init();
+    let target = Box::new(
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("vortext.log")?,
+    );
+    env_logger::builder()
+        .target(env_logger::Target::Pipe(target))
+        .filter_level(log::LevelFilter::Debug)
+        .init();
     let builder = PrometheusBuilder::new();
     builder.install().unwrap();
 


### PR DESCRIPTION
This gets rid manually shutting down sockets before closing them. First off the implementation was broken since I cancelled all operations before shutting down which means I never got to read the EOF which would clean up the sockets properly. This caused the application to hang when sending a shutdown command or when the torrent finished. A proper impl would cancel only pending writes but that would be even more complex since I would then need to track the event id of the reoccuring recv operation.

It was also a whole lot of complexity for something I didn't even need (compared to simply closing the sockets).

There are still bugs left hence 1/2, a lot of them stem from me using Slab which really isn't the right datastructure for events since it's impossible to reason about all the index reuse when I start deleting events and connections. Will move over to SlotMap in the next PR