### PR TITLE
Ensure event ids are unique + connection shutdown cleanup 2/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /assets
 /downloaded
+.cargo/config.toml
 routing_table.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,9 +2123,9 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slotmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "serde",
  "sha1",
  "slab",
+ "slotmap",
  "smallvec 2.0.0-alpha.11",
  "socket2 0.6.0",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,8 @@ overflow-checks = true
 # debug = true 
 lto = true
 
+[profile.dev]
+debug = 2
+
 [profile.release.package."*"]
 opt-level = 3

--- a/bittorrent/Cargo.toml
+++ b/bittorrent/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 [dependencies]
 io-uring = "0.7"
 libc = "0.2"
+slotmap = "1"
 slab = "0.4"
 bytes = { workspace = true }
 bitvec = { version = "1.0", default-features = false, features = ["alloc"]}

--- a/bittorrent/src/buf_pool.rs
+++ b/bittorrent/src/buf_pool.rs
@@ -19,7 +19,7 @@ impl BufferPool {
             allocated_buffers: Slab::with_capacity(entries),
         }
     }
-    pub fn get_buffer(&mut self) -> Buffer {
+    pub fn get_buffer(&mut self) -> Buffer<'_> {
         match self.free.pop() {
             Some(free_idx) => Buffer {
                 index: free_idx,

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -404,6 +404,11 @@ impl<'scope, 'state: 'scope> EventLoop {
                         // Only cancellation errors are expected here
                         // since linked timeouts share event id with
                         // the event being on a timer
+                        //
+                        // TODO: We might also end up here if we remove event id for a
+                        // reoccuring event like recv_multi even though we've cancelled
+                        // all events + close the socket if we've received multiple cqe for
+                        // the event in one submission
                         assert_eq!(err as i32, ECANCELED);
                     }
                     // Ensure bids are always returned

--- a/bittorrent/src/file_store/mod.rs
+++ b/bittorrent/src/file_store/mod.rs
@@ -217,12 +217,12 @@ impl FileStore {
                 let num_pieces = (torrent_file.length as u64 + start_offset as u64) / piece_length;
                 let offset = (torrent_file.length as u64 + start_offset as u64) % piece_length;
                 let file_path = torrent_directory.as_path().join(torrent_file.path);
-                if let Some(parent_dir) = file_path.parent() {
-                    if let Err(err) = std::fs::create_dir_all(parent_dir) {
-                        // Do not error if they folders already exists
-                        if err.kind() != io::ErrorKind::AlreadyExists {
-                            return Err(err);
-                        }
+                if let Some(parent_dir) = file_path.parent()
+                    && let Err(err) = std::fs::create_dir_all(parent_dir)
+                {
+                    // Do not error if they folders already exists
+                    if err.kind() != io::ErrorKind::AlreadyExists {
+                        return Err(err);
                     }
                 }
                 let file_handle = MmapFile::create(&file_path, torrent_file.length as usize)?;

--- a/bittorrent/src/io_utils.rs
+++ b/bittorrent/src/io_utils.rs
@@ -202,7 +202,6 @@ pub fn recv<Q: SubmissionQueue>(
         .user_data(event_data_idx.data().as_ffi())
         .flags(io_uring::squeue::Flags::BUFFER_SELECT | io_uring::squeue::Flags::IO_LINK);
 
-    //let user_data = UserData::new(user_data.event_idx as _, None);
     let timeout_op = opcode::LinkTimeout::new(timeout)
         .build()
         .user_data(event_data_idx.data().as_ffi());

--- a/bittorrent/src/io_utils.rs
+++ b/bittorrent/src/io_utils.rs
@@ -147,7 +147,6 @@ pub fn write_to_connection<Q: SubmissionQueue>(
     sq.push(write_op);
 }
 
-
 // NOTE: Socket contains an OwnedFd which automatically closes
 // the file descriptor in a blocking fashion upon dropping it.
 // That's great for a fallback since closing sockets should rarely block
@@ -235,4 +234,3 @@ pub fn recv_multishot<Q: SubmissionQueue>(
         .flags(io_uring::squeue::Flags::BUFFER_SELECT);
     sq.push(read_op);
 }
-

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -172,15 +172,13 @@ impl InitializedState {
                         for (conn_id, peer) in connections.iter_mut() {
                             if let Some(bitfield) =
                                 self.piece_selector.interesting_peer_pieces(conn_id)
+                                && !bitfield.any()
+                                && peer.is_interesting
+                                && peer.queued.is_empty()
+                                && peer.inflight.is_empty()
                             {
-                                if !bitfield.any()
-                                    && peer.is_interesting
-                                    && peer.queued.is_empty()
-                                    && peer.inflight.is_empty()
-                                {
-                                    // We are no longer interestead in this peer
-                                    peer.not_interested(false);
-                                }
+                                // We are no longer interestead in this peer
+                                peer.not_interested(false);
                             }
                             peer.have(completed_piece.index as i32, false);
                         }

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -398,10 +398,15 @@ mod test_utils {
     use lava_torrent::torrent::v1::{Torrent, TorrentBuilder};
     use socket2::{Domain, Protocol, Socket, Type};
 
-    pub fn generate_peer(fast_ext: bool, conn_id: usize) -> PeerConnection {
+    pub fn generate_peer(
+        fast_ext: bool,
+        conn_id: crate::event_loop::ConnectionId,
+    ) -> PeerConnection {
         let socket_a = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
+        let peer_addr = "127.0.0.1:0".parse().unwrap();
         PeerConnection::new(
             socket_a,
+            peer_addr,
             conn_id,
             ParsedHandshake {
                 peer_id: generate_peer_id(),

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -247,8 +247,12 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             ConnectionState::Connected(socket) => {
                 io_utils::close_socket(sq, socket, Some(self.conn_id), events);
             }
-            // Should never disconnect twice
-            ConnectionState::Disconnecting => unreachable!(),
+            ConnectionState::Disconnecting => {
+                // Should not disconnect twice but I could see it happening if an earlier
+                // cqe disconnects the peer for some reason and then there being multiple cqe's
+                // left for the same peer that also contain corrupted data for example
+                return;
+            }
         }
         if let Some((_, torrent_state)) = state_ref.state() {
             self.release_all_pieces(torrent_state);

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -140,7 +140,11 @@ impl PieceSelector {
     }
 
     // Updates the interesting peer pieces and returns if the peer has any interesting pieces
-    pub fn peer_bitfield(&mut self, connection_id: ConnectionId, peer_pieces: BitBox<u8, Msb0>) -> bool {
+    pub fn peer_bitfield(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_pieces: BitBox<u8, Msb0>,
+    ) -> bool {
         let not_completed = !self.completed_pieces.clone();
         let interesting_pieces = peer_pieces & not_completed;
         let is_interesting = interesting_pieces.any();
@@ -150,7 +154,11 @@ impl PieceSelector {
     }
 
     // Updates the interesting peer pieces tracking and returns if the piece index was interesting
-    pub fn update_peer_piece_intrest(&mut self, connection_id: ConnectionId, piece_index: usize) -> bool {
+    pub fn update_peer_piece_intrest(
+        &mut self,
+        connection_id: ConnectionId,
+        piece_index: usize,
+    ) -> bool {
         let is_interesting = !self.completed_pieces[piece_index];
         let entry = self.interesting_peer_pieces.entry(connection_id);
         entry
@@ -165,7 +173,10 @@ impl PieceSelector {
     }
 
     // All interesting peer pieces if a bitfield has been received
-    pub fn interesting_peer_pieces(&self, connection_id: ConnectionId) -> Option<&BitBox<u8, Msb0>> {
+    pub fn interesting_peer_pieces(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Option<&BitBox<u8, Msb0>> {
         self.interesting_peer_pieces.get(&connection_id)
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -121,7 +121,8 @@ fn main() -> io::Result<()> {
     let target = Box::new(
         OpenOptions::new()
             .create(true)
-            .append(true)
+            .write(true)
+            .truncate(true)
             .open("vortex.log")?,
     );
     env_logger::builder()

--- a/dht/src/krpc.rs
+++ b/dht/src/krpc.rs
@@ -121,7 +121,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn ping(&self, body: Ping) -> QueryBuilder<'_,Ping> {
+    pub fn ping(&self, body: Ping) -> QueryBuilder<'_, Ping> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,
@@ -141,7 +141,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn get_peers(&self, body: GetPeers) -> QueryBuilder<'_,GetPeers> {
+    pub fn get_peers(&self, body: GetPeers) -> QueryBuilder<'_, GetPeers> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,
@@ -151,7 +151,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn announce_peer(&self, body: AnnouncePeer) -> QueryBuilder<'_,AnnouncePeer> {
+    pub fn announce_peer(&self, body: AnnouncePeer) -> QueryBuilder<'_, AnnouncePeer> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,

--- a/dht/src/krpc.rs
+++ b/dht/src/krpc.rs
@@ -121,7 +121,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn ping(&self, body: Ping) -> QueryBuilder<Ping> {
+    pub fn ping(&self, body: Ping) -> QueryBuilder<'_,Ping> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,
@@ -131,7 +131,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn find_nodes(&self, body: FindNodes) -> QueryBuilder<FindNodes> {
+    pub fn find_nodes(&self, body: FindNodes) -> QueryBuilder<'_, FindNodes> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,
@@ -141,7 +141,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn get_peers(&self, body: GetPeers) -> QueryBuilder<GetPeers> {
+    pub fn get_peers(&self, body: GetPeers) -> QueryBuilder<'_,GetPeers> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,
@@ -151,7 +151,7 @@ impl KrpcClient {
         }
     }
 
-    pub fn announce_peer(&self, body: AnnouncePeer) -> QueryBuilder<AnnouncePeer> {
+    pub fn announce_peer(&self, body: AnnouncePeer) -> QueryBuilder<'_,AnnouncePeer> {
         let transaction_id = self.gen_transaction_id();
         QueryBuilder {
             id: transaction_id,


### PR DESCRIPTION
This migrates (back? can't remember) to slotmap to prevent nefarious event or connection id reuse. It's way to complex and buggy to try and reuse event ids without taking into account the "version" since everything is asynchronous and events may be received after being "cancelled" due to each submission  cycle deals with multiple cqes. The previous implementation was fundamentally broken.

This also improves connection shutdown by only removing peers after the connection has been closed properly. It makes it easier to reason about and clearer code imo