### PR TITLE
Fix accept connection flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture
+
+Vortex is a high-performance BitTorrent client built in Rust using io-uring for asynchronous I/O. The project is structured as a Cargo workspace with four main components:
+
+- **`cli/`**: Terminal UI application using Ratatui for downloading torrents with DHT support. This is the primary client crate used to test that the `bittorrent` crate can be used to create meaingful applications.
+- **`bittorrent/`**: Core BitTorrent protocol implementation built on io-uring. This is the main crate of this repository and is the one being actively developed. Your focus should be on this crate.
+- **`dht/`**: Distributed Hash Table implementation for peer discovery. This is no longer actively developed and mainly here for historical reasons. You can ignore this crate unless explicitly told otherwise.
+- **`utp-socket/`**: µTP (Micro Transport Protocol) socket implementation. This is no longer actively developed and no longer maintained. You can ignore this crate unless explicitly told otherwise.
+
+The bittorrent crate uses an event-driven architecture with io-uring for high-performance networking. Key modules include:
+- `event_loop`: Central event dispatcher managing connections and I/O
+- `peer_comm`: Peer connection management and protocol handling
+- `peer_comm/tests.rs`: Peer protocol tests which require no prior setup (like podman containers)
+- `piece_selector`: Download strategy and piece management
+- `file_store`: Disk I/O operations for torrent data
+
+## Development Commands
+
+### Building and Testing
+```bash
+# Build all workspace members
+cargo build
+
+# Run the unit tests for the protocol logic
+cargo test --package vortex-bittorrent -- peer_comm::tests
+
+# Run all tests including integration tests (requires Docker/Podman for Transmission containers)
+just test
+
+# Run specific integration test locally
+just test-locally
+
+# Format code
+cargo fmt
+
+# Lint code
+cargo clippy --all-features --all-targets -- -D warnings
+
+# Check dependencies for security issues and licensing
+cargo deny check
+```
+
+### Integration Test Environment Setup
+Tests use Transmission containers for seeding torrents. The `just test` command automatically:
+1. Generates test files if needed
+2. Sets up Transmission seed containers via `scripts/transmission_containers.sh`
+3. Runs tests with `cargo nextest`
+
+### Monitoring
+Set up Grafana dashboard for metrics:
+```bash
+just setup-grafana
+```
+
+## Key Dependencies and Constraints
+
+- **io-uring**: Linux-specific async I/O interface (requires Linux)
+- **cargo-deny**: Enforces dependency policies (see `deny.toml`)
+- **jemalloc**: Used as global allocator in CLI
+- **Edition 2024**: All crates use Rust edition 2024
+
+Banned dependencies include OpenSSL, async-std, and deprecated crates as specified in `deny.toml`.
+
+## CLI Usage
+The CLI (`vortex-cli`) provides a terminal interface for downloading torrents with real-time progress visualization and DHT peer discovery.

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -311,6 +311,14 @@ impl<'scope, 'state: 'scope> EventLoop {
         let port = self.setup_listener(&mut ring);
         state.listener_port = Some(port);
 
+        // Emit listener started event
+        if event_tx
+            .enqueue(TorrentEvent::ListenerStarted { port })
+            .is_err()
+        {
+            log::error!("Failed to enqueue ListenerStarted event");
+        }
+
         let mut state_ref = state.as_ref();
 
         let mut prev_state_initialized = state_ref.is_initialzied();

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -2,21 +2,17 @@ use std::{
     cell::OnceCell,
     collections::VecDeque,
     io::{self},
-    net::{SocketAddrV4, TcpListener},
-    os::fd::{AsRawFd, IntoRawFd},
+    net::SocketAddrV4,
     path::{Path, PathBuf},
     sync::mpsc::{Receiver, Sender},
 };
 
-use event_loop::{ConnectionId, EventData, EventId, EventLoop, EventType};
+use event_loop::{ConnectionId, EventLoop};
 use file_store::FileStore;
 use heapless::spsc::{Consumer, Producer};
-use io_uring::{
-    IoUring, opcode,
-    types::{self},
-};
+use io_uring::IoUring;
 use piece_selector::{CompletedPiece, Piece, PieceSelector, Subpiece};
-use slotmap::{Key, SlotMap};
+use slotmap::SlotMap;
 use thiserror::Error;
 
 mod buf_pool;

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -88,6 +88,9 @@ pub enum Command {
 pub enum TorrentEvent {
     TorrentComplete,
     MetadataComplete(Box<lava_torrent::torrent::v1::Torrent>),
+    ListenerStarted {
+        port: u16,
+    },
     PeerMetrics {
         /// Note that these are not stable and might
         /// be reused

--- a/bittorrent/src/peer_comm/extended_protocol.rs
+++ b/bittorrent/src/peer_comm/extended_protocol.rs
@@ -26,6 +26,9 @@ pub fn extension_handshake_msg(state_ref: &mut StateRef) -> PeerMessage {
         "v",
         bt_bencode::value::to_value(&format!("Vortex {}", env!("CARGO_PKG_VERSION"))).unwrap(),
     );
+    if let Some(listener_port) = state_ref.listener_port {
+        handshake.insert("p", bt_bencode::value::to_value(listener_port).unwrap());
+    }
     if let Some((file_and_meta, _)) = state_ref.state() {
         let metadata_size = file_and_meta.metadata.construct_info().encode().len();
         handshake.insert(

--- a/bittorrent/src/peer_comm/peer_protocol.rs
+++ b/bittorrent/src/peer_comm/peer_protocol.rs
@@ -94,7 +94,7 @@ pub fn write_handshake(our_peer_id: PeerId, info_hash: [u8; 20], mut buffer: &mu
     buffer.put_slice(&our_peer_id.0 as &[u8]);
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(transparent)]
 pub struct PeerId([u8; 20]);
 

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -2101,6 +2101,7 @@ fn metadata_extension_piece_bounds_validation() {
 fn extension_handshake_generates_correct_message() {
     use crate::peer_comm::extended_protocol::extension_handshake_msg;
     let mut download_state = setup_test();
+    download_state.listener_port = Some(1234);
 
     let mut state_ref = download_state.as_ref();
     let handshake = extension_handshake_msg(&mut state_ref);
@@ -2126,7 +2127,7 @@ fn extension_handshake_generates_correct_message() {
         assert!(m.contains_key("ut_metadata".as_bytes()));
 
         assert!(dict.contains_key("v".as_bytes()));
-
+        assert_eq!(dict.get("p".as_bytes()).unwrap().as_u64().unwrap(), 1234);
         assert_eq!(
             dict.get("reqq".as_bytes()).unwrap().as_u64().unwrap(),
             MAX_OUTSTANDING_REQUESTS

--- a/bittorrent/tests/basic.rs
+++ b/bittorrent/tests/basic.rs
@@ -68,6 +68,7 @@ fn basic_seeded_download() {
                         pieces_allocated: _,
                         num_connections: _,
                     } => {}
+                    TorrentEvent::ListenerStarted { port: _ } => {}
                 }
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,6 +251,9 @@ impl<'queue> VortexApp<'queue> {
                     //let elapsed = self.start_time.elapsed();
                     self.shutdown();
                 }
+                TorrentEvent::ListenerStarted { port: _ } => {
+                    // Nothing to do here
+                }
                 TorrentEvent::MetadataComplete(metadata) => {
                     self.metadata = Some(metadata);
                 }

--- a/dht/src/krpc/protocol.rs
+++ b/dht/src/krpc/protocol.rs
@@ -334,7 +334,7 @@ impl TryFrom<Answer> for AnnounceResponse {
 }
 
 fn deserialize_compact_nodes(bytes: ByteBuf) -> Vec<Node> {
-    if (bytes.len() % 26) != 0 {
+    if !bytes.len().is_multiple_of(26) {
         log::warn!("Invalid compact node buffer, not divisible by 26");
     }
     bytes


### PR DESCRIPTION
Accepting connections was broken in multiple ways. First of the listener was dropped before entering the event loop, after that the handler relied on the previous old way of reusing event keys. I've now fixed that so it uses the same code path as the out going connections fixing some bugs along the way (ex not crashing if a connection isn't in pending_connections).


Also added Claude.md to see if that makes the AI agents work better. Currently using them to help writing tests and doing boring refactors (ex update all tests after some internal function signature change).