### PR TITLE
Track upload speed in `PeerMetrics` and support resuming from partially downloaded content

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -985,8 +985,8 @@ pub(crate) fn tick<'scope, 'state: 'scope>(
             // Take delta into account when calculating throughput
             connection.download_throughput =
                 (connection.download_throughput as f64 / tick_delta.as_secs_f64()).round() as u64;
-            connection.upload_thorughput =
-                (connection.upload_thorughput as f64 / tick_delta.as_secs_f64()).round() as u64;
+            connection.upload_throughput =
+                (connection.upload_throughput as f64 / tick_delta.as_secs_f64()).round() as u64;
             if !connection.peer_choking {
                 // slow start win size increase is handled in update_stats
                 if !connection.slow_start {
@@ -1006,9 +1006,9 @@ pub(crate) fn tick<'scope, 'state: 'scope>(
                 connection.slow_start = false;
             }
             connection.prev_download_throughput = connection.download_throughput;
-            connection.prev_upload_throughput = connection.upload_thorughput;
+            connection.prev_upload_throughput = connection.upload_throughput;
             connection.download_throughput = 0;
-            connection.upload_thorughput = 0;
+            connection.upload_throughput = 0;
         }
     }
     let mut peer_metrics = Vec::with_capacity(connections.len());

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1008,6 +1008,7 @@ pub(crate) fn tick<'scope, 'state: 'scope>(
             connection.prev_download_throughput = connection.download_throughput;
             connection.prev_upload_throughput = connection.upload_thorughput;
             connection.download_throughput = 0;
+            connection.upload_thorughput = 0;
         }
     }
     let mut peer_metrics = Vec::with_capacity(connections.len());

--- a/bittorrent/src/file_store/mod.rs
+++ b/bittorrent/src/file_store/mod.rs
@@ -421,9 +421,7 @@ mod tests {
                 view.write_subpiece(subpiece_offset, subpiece_data, &file_store);
             }
             let readable = view.into_readable();
-            let hash_matches = readable
-                .check_hash(piece_hash, &file_store, true)
-                .unwrap();
+            let hash_matches = readable.check_hash(piece_hash, &file_store, true).unwrap();
             assert!(hash_matches);
             all_data = remainder.to_vec();
         }

--- a/bittorrent/src/file_store/mod.rs
+++ b/bittorrent/src/file_store/mod.rs
@@ -137,11 +137,12 @@ impl ReadablePieceFileView {
         assert_eq!(subpiece_read, buffer.len());
     }
 
-    /// Sync the relevant file pieces to disk and compare against expected hash
-    pub fn sync_and_check_hash(
+    /// Compare against the expected hash and optionally sync the files to disk
+    pub fn check_hash(
         &self,
         expected_piece_hash: &[u8],
         file_store: &FileStore,
+        sync: bool,
     ) -> io::Result<bool> {
         let mut hasher = sha1::Sha1::new();
         let mut total_read = 0;
@@ -170,7 +171,9 @@ impl ReadablePieceFileView {
             let file_data = file.file_handle.get();
             let file_data_start = file_offset as usize;
             let file_data_end = file_offset as usize + to_read;
-            file.file_handle.sync(file_data_start, file_data_end)?;
+            if sync {
+                file.file_handle.sync(file_data_start, file_data_end)?;
+            }
             let relevant_piece_data: &[u8] = &file_data[file_data_start..file_data_end];
             hasher.update(relevant_piece_data);
             total_read += to_read;
@@ -419,7 +422,7 @@ mod tests {
             }
             let readable = view.into_readable();
             let hash_matches = readable
-                .sync_and_check_hash(piece_hash, &file_store)
+                .check_hash(piece_hash, &file_store, true)
                 .unwrap();
             assert!(hash_matches);
             all_data = remainder.to_vec();

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -13,9 +13,7 @@ use file_store::FileStore;
 use heapless::spsc::{Consumer, Producer};
 use io_uring::IoUring;
 use piece_selector::{CompletedPiece, Piece, PieceSelector, Subpiece};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use slotmap::SlotMap;
 use thiserror::Error;
 

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -81,7 +81,8 @@ pub enum Command {
 
 #[derive(Debug)]
 pub struct PeerMetrics {
-    pub throuhgput: u64,
+    pub download_throughput: u64,
+    pub upload_throughput: u64,
     pub endgame: bool,
     pub snubbed: bool,
 }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -178,7 +178,7 @@ pub struct PeerConnection {
     pub moving_rtt: MovingRttAverage,
     pub download_throughput: u64,
     pub prev_download_throughput: u64,
-    pub upload_thorughput: u64,
+    pub upload_throughput: u64,
     pub prev_upload_throughput: u64,
     // If this connection is about to be disconnected
     pub pending_disconnect: Option<DisconnectReason>,
@@ -228,7 +228,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             pending_disconnect: None,
             download_throughput: 0,
             prev_download_throughput: 0,
-            upload_thorughput: 0,
+            upload_throughput: 0,
             prev_upload_throughput: 0,
             outgoing_msgs_buffer: Default::default(),
             extensions: Default::default(),
@@ -314,7 +314,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     fn send_piece(&mut self, index: i32, offset: i32, data: Bytes, ordered: bool) {
-        self.upload_thorughput += data.len() as u64;
+        self.upload_throughput += data.len() as u64;
         self.outgoing_msgs_buffer.push(OutgoingMsg {
             message: PeerMessage::Piece {
                 index,

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -1062,7 +1062,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     scope.spawn(move |_| {
                         let hash = &torrent_info.pieces[readable_piece_view.index as usize];
                         let hash_check_result =
-                            readable_piece_view.sync_and_check_hash(hash, file_store);
+                            readable_piece_view.check_hash(hash, file_store, true);
                         complete_tx
                             .send(CompletedPiece {
                                 index: index as usize,

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -176,8 +176,10 @@ pub struct PeerConnection {
     pub snubbed: bool,
     // The averge time between pieces being received
     pub moving_rtt: MovingRttAverage,
-    pub throughput: u64,
-    pub prev_throughput: u64,
+    pub download_throughput: u64,
+    pub prev_download_throughput: u64,
+    pub upload_thorughput: u64,
+    pub prev_upload_throughput: u64,
     // If this connection is about to be disconnected
     pub pending_disconnect: Option<DisconnectReason>,
     pub stateful_decoder: PeerMessageDecoder,
@@ -224,8 +226,10 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             max_queue_size: 200,
             moving_rtt: Default::default(),
             pending_disconnect: None,
-            throughput: 0,
-            prev_throughput: 0,
+            download_throughput: 0,
+            prev_download_throughput: 0,
+            upload_thorughput: 0,
+            prev_upload_throughput: 0,
             outgoing_msgs_buffer: Default::default(),
             extensions: Default::default(),
             stateful_decoder: PeerMessageDecoder::new(2 << 15),
@@ -310,6 +314,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     fn send_piece(&mut self, index: i32, offset: i32, data: Bytes, ordered: bool) {
+        self.upload_thorughput += data.len() as u64;
         self.outgoing_msgs_buffer.push(OutgoingMsg {
             message: PeerMessage::Piece {
                 index,
@@ -440,7 +445,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         if self.slow_start {
             self.update_target_inflight(self.target_inflight + 1);
         }
-        self.throughput += length as u64;
+        self.download_throughput += length as u64;
         let request = self.inflight.remove(pos).unwrap();
         log::trace!("Subpiece completed: {}, {}", request.index, request.offset);
         let rtt = self.last_received_subpiece.take().unwrap().elapsed();
@@ -457,7 +462,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                 metrics::gauge!("peer.throughput.bytes", "peer_id" => self.peer_id.to_string());
             // Prev throughput is used since the mertics are reported at the end of TICK and
             // throughput have been reset and stored here at that point
-            gauge.set(self.prev_throughput as u32);
+            gauge.set(self.prev_download_throughput as u32);
 
             let gauge =
                 metrics::gauge!("peer.target_inflight", "peer_id" => self.peer_id.to_string());
@@ -481,7 +486,9 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         PeerMetrics {
             // Prev throughput is used since the mertics are reported at the end of TICK and
             // throughput have been reset and stored here at that point
-            throuhgput: self.prev_throughput,
+            download_throughput: self.prev_download_throughput,
+            // Same goes for upload data
+            upload_throughput: self.prev_upload_throughput,
             endgame: self.endgame,
             snubbed: self.snubbed,
         }

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -2367,7 +2367,7 @@ fn upload_throughput_tracking() {
         connections[key].handle_message(PeerMessage::HaveNone, &mut state_ref, scope);
         connections[key].handle_message(PeerMessage::Interested, &mut state_ref, scope);
 
-        assert_eq!(connections[key].upload_thorughput, 0);
+        assert_eq!(connections[key].upload_throughput, 0);
         assert_eq!(connections[key].prev_upload_throughput, 0);
 
         connections[key].handle_message(
@@ -2381,7 +2381,7 @@ fn upload_throughput_tracking() {
         );
 
         // After sending the piece, upload throughput should be tracked
-        assert_eq!(connections[key].upload_thorughput, SUBPIECE_SIZE as u64);
+        assert_eq!(connections[key].upload_throughput, SUBPIECE_SIZE as u64);
 
         // Request another subpiece
         connections[key].handle_message(
@@ -2395,7 +2395,7 @@ fn upload_throughput_tracking() {
         );
 
         // Upload throughput should accumulate
-        assert_eq!(connections[key].upload_thorughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(connections[key].upload_throughput, (SUBPIECE_SIZE * 2) as u64);
 
         // Simulate a tick to move current throughput to prev_throughput
         let mut event_q = Queue::<TorrentEvent, 512>::new();
@@ -2410,6 +2410,6 @@ fn upload_throughput_tracking() {
 
         // After tick, current throughput is reset and moved to prev
         assert_eq!(connections[key].prev_upload_throughput, ((SUBPIECE_SIZE * 2) as f64 / 1.5) as u64);
-        assert_eq!(connections[key].upload_thorughput, 0);
+        assert_eq!(connections[key].upload_throughput, 0);
     });
 }

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -311,8 +311,8 @@ fn slow_start() {
             &mut event_tx,
         );
         assert!(connections[key].slow_start);
-        assert_eq!(connections[key].prev_throughput, 0);
-        assert_eq!(connections[key].throughput, 0);
+        assert_eq!(connections[key].prev_download_throughput, 0);
+        assert_eq!(connections[key].download_throughput, 0);
         assert!(connections[key].target_inflight > 1);
         let old_desired_queue = connections[key].target_inflight;
 
@@ -350,9 +350,9 @@ fn slow_start() {
             &mut state_ref,
             scope,
         );
-        assert_eq!(connections[key].throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(connections[key].download_throughput, (SUBPIECE_SIZE * 2) as u64);
         assert!(connections[key].slow_start);
-        assert_eq!(connections[key].prev_throughput, 0);
+        assert_eq!(connections[key].prev_download_throughput, 0);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 2);
 
         tick(
@@ -363,8 +363,8 @@ fn slow_start() {
             &mut event_tx,
         );
 
-        assert_eq!(connections[key].prev_throughput, 21845);
-        assert_eq!(connections[key].throughput, 0);
+        assert_eq!(connections[key].prev_download_throughput, 21845);
+        assert_eq!(connections[key].download_throughput, 0);
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 2);
 
@@ -405,7 +405,7 @@ fn slow_start() {
             &mut event_tx,
         );
 
-        assert_eq!(connections[key].prev_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(connections[key].prev_download_throughput, (SUBPIECE_SIZE * 2) as u64);
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 4);
 
@@ -447,7 +447,7 @@ fn slow_start() {
             &mut event_tx,
         );
 
-        assert_eq!(connections[key].prev_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(connections[key].prev_download_throughput, (SUBPIECE_SIZE * 2) as u64);
         // No longer slow start
         assert!(!connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 6);

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -6,9 +6,15 @@ use serde::Deserialize;
 use slotmap::SlotMap;
 
 use crate::{
-    event_loop::{tick, ConnectionId, MAX_OUTSTANDING_REQUESTS}, peer_comm::{extended_protocol::MetadataMessage, peer_connection::DisconnectReason}, peer_connection::OutgoingMsg, piece_selector::{Subpiece, SUBPIECE_SIZE}, test_utils::{
-        generate_peer, setup_seeding_test, setup_test, setup_uninitialized_test, setup_uninitialized_test_with_metadata_size
-    }, TorrentEvent
+    TorrentEvent,
+    event_loop::{ConnectionId, MAX_OUTSTANDING_REQUESTS, tick},
+    peer_comm::{extended_protocol::MetadataMessage, peer_connection::DisconnectReason},
+    peer_connection::OutgoingMsg,
+    piece_selector::{SUBPIECE_SIZE, Subpiece},
+    test_utils::{
+        generate_peer, setup_seeding_test, setup_test, setup_uninitialized_test,
+        setup_uninitialized_test_with_metadata_size,
+    },
 };
 
 use super::{peer_connection::PeerConnection, peer_protocol::PeerMessage};
@@ -344,7 +350,10 @@ fn slow_start() {
             &mut state_ref,
             scope,
         );
-        assert_eq!(connections[key].download_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(
+            connections[key].download_throughput,
+            (SUBPIECE_SIZE * 2) as u64
+        );
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].prev_download_throughput, 0);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 2);
@@ -399,7 +408,10 @@ fn slow_start() {
             &mut event_tx,
         );
 
-        assert_eq!(connections[key].prev_download_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(
+            connections[key].prev_download_throughput,
+            (SUBPIECE_SIZE * 2) as u64
+        );
         assert!(connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 4);
 
@@ -441,7 +453,10 @@ fn slow_start() {
             &mut event_tx,
         );
 
-        assert_eq!(connections[key].prev_download_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(
+            connections[key].prev_download_throughput,
+            (SUBPIECE_SIZE * 2) as u64
+        );
         // No longer slow start
         assert!(!connections[key].slow_start);
         assert_eq!(connections[key].target_inflight, old_desired_queue + 6);
@@ -2395,7 +2410,10 @@ fn upload_throughput_tracking() {
         );
 
         // Upload throughput should accumulate
-        assert_eq!(connections[key].upload_throughput, (SUBPIECE_SIZE * 2) as u64);
+        assert_eq!(
+            connections[key].upload_throughput,
+            (SUBPIECE_SIZE * 2) as u64
+        );
 
         // Simulate a tick to move current throughput to prev_throughput
         let mut event_q = Queue::<TorrentEvent, 512>::new();
@@ -2409,7 +2427,10 @@ fn upload_throughput_tracking() {
         );
 
         // After tick, current throughput is reset and moved to prev
-        assert_eq!(connections[key].prev_upload_throughput, ((SUBPIECE_SIZE * 2) as f64 / 1.5) as u64);
+        assert_eq!(
+            connections[key].prev_upload_throughput,
+            ((SUBPIECE_SIZE * 2) as f64 / 1.5) as u64
+        );
         assert_eq!(connections[key].upload_throughput, 0);
     });
 }

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -78,6 +78,11 @@ impl PieceSelector {
         }
     }
 
+    pub(crate) fn set_completed_bitfield(&mut self, completed_pieces: BitBox<u8, Msb0>) {
+        assert_eq!(self.completed_pieces.len(), completed_pieces.len());
+        self.completed_pieces = completed_pieces;
+    }
+
     // Returns index and if the peer is in endgame mode
     pub fn next_piece(
         &mut self,

--- a/bittorrent/tests/basic.rs
+++ b/bittorrent/tests/basic.rs
@@ -16,7 +16,7 @@ fn basic_seeded_download() {
     let our_id = generate_peer_id();
     let mut torrent = Torrent::new(
         our_id,
-        State::unstarted_from_metadata(metadata, "../downloaded".into()).unwrap(),
+        State::from_metadata_and_root(metadata, "../downloaded".into()).unwrap(),
     );
 
     let download_time = Instant::now();


### PR DESCRIPTION
first steps in properly tracking upload speed, first adding fields to the PeerMetrics struct so that clients can visualize it. I've done this for the cli but I never seem to upload anything. Most likely a bug but could be the network setup I'm testing with as well. Haven't investigated further for now since this pr already became larger than expected.

As a side benefit of me wanting to test this properly you can now resume started torrents in the cli and the cli automatically saves the metadata to disk when it's completed. This is also necessary for seeding scenarios which I'm going to look more into soon