### PR TITLE
Generate peer id prefix based off crate version

### DIFF
--- a/bittorrent/src/peer_comm/peer_protocol.rs
+++ b/bittorrent/src/peer_comm/peer_protocol.rs
@@ -547,7 +547,6 @@ mod tests {
         assert_eq!(&prefix, b"-VT1203-");
     }
 
-
     #[test]
     fn fuzz_encoded_length_bug() {
         let messages = [


### PR DESCRIPTION
Use the crate version to generate the peer id prefix so I don't have to manually bump this
