### PR TITLE
fix: Avoid double panic in buf_ring destructor

### DIFF
--- a/bittorrent/src/buf_ring.rs
+++ b/bittorrent/src/buf_ring.rs
@@ -209,7 +209,7 @@ impl BufferRing {
 
 impl Drop for BufferRing {
     fn drop(&mut self) {
-        if self.is_registerd {
+        if self.is_registerd && !std::thread::panicking() {
             panic!("Must unregister before dropping");
         }
     }


### PR DESCRIPTION
the check in the destructor is only there for non panicking code that forgets to unregister the buffer