### PR TITLE
Migrate to mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1560,15 @@ dependencies = [
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2711,26 +2730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,9 +2992,9 @@ dependencies = [
  "log",
  "mainline",
  "metrics-exporter-prometheus",
+ "mimalloc",
  "ratatui",
  "serde",
- "tikv-jemallocator",
  "toml",
  "vortex-bittorrent",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 env_logger = { workspace = true }
 vortex-bittorrent = { path = "../bittorrent", version = "0.5" }
 heapless = { workspace = true }
-tikv-jemallocator = "0.6"
+mimalloc = { version = "0.1.48", features = ["v3"] }
 mainline = { version = "6", default-features = false, features = ["node"]}
 metrics-exporter-prometheus = { workspace = true, optional = true }
 clap = { version = "4.5.60", features = ["derive"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,10 +25,10 @@ use ui::{
     extract_throughput_data,
 };
 
-use tikv_jemallocator::Jemalloc;
+use mimalloc::MiMalloc;
 
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: MiMalloc = MiMalloc;
 
 pub fn decode_info_hash_hex(s: &str) -> color_eyre::eyre::Result<[u8; 20]> {
     let byte_vec = (0..s.len())


### PR DESCRIPTION
Mimalloc is actively developed. It lowered binary size from **34mb** -> **26mb** and anecdotally lowered RSS by 8% any performance difference either way is negligible for an application like this. 

```
# Anecdotal evidence
pidstat -r -u -p $(pgrep vortex-cli) 1
#Mimalloc
08:51:36 PM   UID       PID  minflt/s  majflt/s     VSZ     RSS   %MEM  Command
08:51:37 PM  1000     75462      0.00      0.00 3427536  562052   1.72  vortex-cli


# Jemalloc
08:55:08 PM   UID       PID  minflt/s  majflt/s     VSZ     RSS   %MEM  Command
08:55:09 PM  1000     82555      0.00      0.00 2573532  606460   1.85  vortex-cli
```