### PR TITLE
feat: add torrent selection menu with delete support

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -39,6 +39,8 @@ pub enum AppState {
     },
 }
 
+pub const METADATA_DIR: &str = "metadata";
+
 pub enum Metadata {
     /// Full metadata is available
     Full(Box<lava_torrent::torrent::v1::Torrent>),
@@ -186,14 +188,16 @@ impl<'queue> VortexApp<'queue> {
                     // Store the metadata as the info hash in the download folder, that will
                     // ensure it's possible to recover from downloads that's already started
                     // The thread is used to keep this non blocking
-                    let metadata_dir = root.join("metadata");
+                    let metadata_dir = root.join(METADATA_DIR);
                     if let Err(err) = std::fs::create_dir_all(&metadata_dir) {
                         log::error!("Failed to create metadata directory: {err}");
                     } else {
                         let path = metadata_dir.join(metadata.info_hash());
-                        if let Err(err) = metadata.write_into_file(path) {
-                            log::error!("Failed to save metadata to disk: {err}");
-                        }
+                        std::thread::spawn(move || {
+                            if let Err(err) = metadata.write_into_file(path) {
+                                log::error!("Failed to save metadata to disk: {err}");
+                            }
+                        });
                     }
                 }
                 TorrentEvent::TorrentMetrics {

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -186,12 +186,15 @@ impl<'queue> VortexApp<'queue> {
                     // Store the metadata as the info hash in the download folder, that will
                     // ensure it's possible to recover from downloads that's already started
                     // The thread is used to keep this non blocking
-                    std::thread::spawn(move || {
-                        let path = root.join(metadata.info_hash());
+                    let metadata_dir = root.join("metadata");
+                    if let Err(err) = std::fs::create_dir_all(&metadata_dir) {
+                        log::error!("Failed to create metadata directory: {err}");
+                    } else {
+                        let path = metadata_dir.join(metadata.info_hash());
                         if let Err(err) = metadata.write_into_file(path) {
-                            log::error!("Failed to save metadata to disk: {err}")
+                            log::error!("Failed to save metadata to disk: {err}");
                         }
-                    });
+                    }
                 }
                 TorrentEvent::TorrentMetrics {
                     pieces_completed,

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -189,16 +189,14 @@ impl<'queue> VortexApp<'queue> {
                     // ensure it's possible to recover from downloads that's already started
                     // The thread is used to keep this non blocking
                     let metadata_dir = root.join(METADATA_DIR);
-                    if let Err(err) = std::fs::create_dir_all(&metadata_dir) {
-                        log::error!("Failed to create metadata directory: {err}");
-                    } else {
-                        let path = metadata_dir.join(metadata.info_hash());
-                        std::thread::spawn(move || {
-                            if let Err(err) = metadata.write_into_file(path) {
-                                log::error!("Failed to save metadata to disk: {err}");
-                            }
-                        });
-                    }
+                    let path = metadata_dir.join(metadata.info_hash());
+                    std::thread::spawn(move || {
+                        if let Err(err) = std::fs::create_dir_all(&metadata_dir) {
+                            log::error!("Failed to create metadata directory: {err}");
+                        } else if let Err(err) = metadata.write_into_file(path) {
+                            log::error!("Failed to save metadata to disk: {err}");
+                        }
+                    });
                 }
                 TorrentEvent::TorrentMetrics {
                     pieces_completed,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -158,7 +158,7 @@ fn parse_magnet_link(magnet: &str) -> color_eyre::eyre::Result<MagentInfo> {
 }
 
 #[derive(Debug, Args)]
-#[group(required = true, multiple = false)]
+#[group(multiple = false)]
 struct TorrentInfo {
     /// Info hash of the torrent you want to download.
     /// The metadata will be automatically downloaded
@@ -317,7 +317,25 @@ fn main() -> color_eyre::Result<()> {
     let bt_config = vortex_config.bittorrent;
     let root = paths.download_folder.clone();
 
-    let (state, metadata) = match cli.torrent_info {
+    let torrent_info = if cli.torrent_info.info_hash.is_none()
+        && cli.torrent_info.magnet_link.is_none()
+        && cli.torrent_info.torrent_file.is_none()
+    {
+        let metadata_path = paths.download_folder.join("metadata");
+        let selected_hash = match ui::select_torrent(metadata_path, root.clone())? {
+            Some(hash) => hash,
+            None => return Ok(()),
+        };
+        TorrentInfo {
+            info_hash: Some(selected_hash),
+            magnet_link: None,
+            torrent_file: None,
+        }
+    } else {
+        cli.torrent_info
+    };
+
+    let (state, metadata) = match torrent_info {
         TorrentInfo {
             info_hash: None,
             magnet_link: None,
@@ -333,8 +351,7 @@ fn main() -> color_eyre::Result<()> {
         }
         _ => {
             let mut magnet_name = None;
-            let info_hash_str = cli
-                .torrent_info
+            let info_hash_str = torrent_info
                 .magnet_link
                 .as_deref()
                 .map(|m| -> color_eyre::Result<String> {
@@ -343,10 +360,17 @@ fn main() -> color_eyre::Result<()> {
                     Ok(info.info_hash)
                 })
                 .transpose()?
-                .or_else(|| cli.torrent_info.info_hash.clone())
-                .expect("Info hash or magnet link must be provided");
+                .or_else(|| torrent_info.info_hash.clone());
+            let info_hash = if let Some(hash) = info_hash_str {
+                hash
+            } else {
+                return Err(eyre!(
+                    "No torrent info provided and no saved torrents found."
+                ));
+            };
+
             match lava_torrent::torrent::v1::Torrent::read_from_file(
-                root.join(info_hash_str.to_lowercase()),
+                root.join("metadata").join(info_hash.to_lowercase()),
             ) {
                 Ok(metadata) => {
                     let state =
@@ -356,7 +380,7 @@ fn main() -> color_eyre::Result<()> {
                 Err(lava_torrent::LavaTorrentError::Io(io_err)) => {
                     if io_err.kind() == ErrorKind::NotFound {
                         let state = State::unstarted(
-                            decode_info_hash_hex(&info_hash_str).wrap_err("Invalid info hash")?,
+                            decode_info_hash_hex(&info_hash).wrap_err("Invalid info hash")?,
                             root.clone(),
                             bt_config,
                         );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,6 +37,8 @@ use ui::{
 
 use mimalloc::MiMalloc;
 
+use crate::app::METADATA_DIR;
+
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
@@ -321,7 +323,7 @@ fn main() -> color_eyre::Result<()> {
         && cli.torrent_info.magnet_link.is_none()
         && cli.torrent_info.torrent_file.is_none()
     {
-        let metadata_path = paths.download_folder.join("metadata");
+        let metadata_path = paths.download_folder.join(METADATA_DIR);
         let selected_hash = match ui::select_torrent(metadata_path, root.clone())? {
             Some(hash) => hash,
             None => return Ok(()),
@@ -370,7 +372,7 @@ fn main() -> color_eyre::Result<()> {
             };
 
             match lava_torrent::torrent::v1::Torrent::read_from_file(
-                root.join("metadata").join(info_hash.to_lowercase()),
+                root.join(METADATA_DIR).join(info_hash.to_lowercase()),
             ) {
                 Ok(metadata) => {
                     let state =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 
-use clap::{Args, Parser};
+use clap::{Args, CommandFactory, Parser};
 use color_eyre::eyre::{ContextCompat, WrapErr, eyre};
 use crossbeam_channel::{Receiver, bounded, select, tick};
 use heapless::spsc::Queue;
@@ -364,9 +364,9 @@ fn main() -> color_eyre::Result<()> {
             let info_hash = if let Some(hash) = info_hash_str {
                 hash
             } else {
-                return Err(eyre!(
-                    "No torrent info provided and no saved torrents found."
-                ));
+                Cli::command().print_help()?;
+                println!();
+                return Ok(());
             };
 
             match lava_torrent::torrent::v1::Torrent::read_from_file(

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -395,7 +395,9 @@ pub fn select_torrent(
 
     let mut terminal = ratatui::init();
     let result = run_selection_menu(&mut terminal, items, metadata_path, download_root)?;
-    ratatui::restore();
+    if result.is_none() {
+        ratatui::restore();
+    }
     Ok(result)
 }
 
@@ -520,6 +522,11 @@ fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
 
                     state.items.remove(idx);
 
+                    if state.items.is_empty() {
+                        state.should_quit = true;
+                        return Ok(());
+                    }
+
                     if state.selected_index >= state.items.len() {
                         state.selected_index = state.items.len().saturating_sub(1);
                     }
@@ -534,6 +541,13 @@ fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
                 _ => {}
             }
         } else {
+            if state.items.is_empty() {
+                match key.code {
+                    KeyCode::Char('q') => state.should_quit = true,
+                    _ => {}
+                }
+                return Ok(());
+            }
             match key.code {
                 KeyCode::Up => {
                     if state.selected_index > 0 {

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -542,9 +542,8 @@ fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
             }
         } else {
             if state.items.is_empty() {
-                match key.code {
-                    KeyCode::Char('q') => state.should_quit = true,
-                    _ => {}
+                if let KeyCode::Char('q') = key.code {
+                    state.should_quit = true
                 }
                 return Ok(());
             }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,15 +1,24 @@
 //! UI components for the TUI application.
 
-use std::time::{Duration, SystemTime};
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
+use color_eyre::eyre::{Result as EyreResult, eyre};
 use heapless::HistoryBuf;
 use human_bytes::human_bytes;
 use ratatui::{
-    layout::Alignment,
+    DefaultTerminal, Frame,
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
+    layout::{Alignment, Constraint, Layout},
     prelude::{Buffer, Rect},
     style::{Color, Modifier, Style, Stylize, palette::tailwind},
     text::Span,
-    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, Row, Table, Widget},
+    widgets::{
+        Axis, Block, Borders, Chart, Dataset, Gauge, List, ListItem, ListState, Paragraph, Row,
+        Table, Widget,
+    },
 };
 use vortex_bittorrent::MetadataProgress;
 
@@ -353,4 +362,204 @@ impl Widget for Footer {
 
 pub fn extract_throughput_data(buf: &HistoryBuf<(f64, f64), 256>) -> Vec<(f64, f64)> {
     buf.oldest_ordered().copied().collect()
+}
+
+pub fn select_torrent(
+    metadata_path: PathBuf,
+    download_root: PathBuf,
+) -> EyreResult<Option<String>> {
+    std::fs::create_dir_all(&metadata_path)?;
+
+    let mut items = Vec::new();
+    for entry in std::fs::read_dir(&metadata_path)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+        if name_str.len() == 40 && name_str.chars().all(|c| c.is_ascii_hexdigit()) {
+            let hash = name_str.to_string();
+            let display_name = lava_torrent::torrent::v1::Torrent::read_from_file(entry.path())
+                .ok()
+                .map(|t| t.name)
+                .unwrap_or_else(|| hash.clone());
+
+            items.push((hash, display_name));
+        }
+    }
+
+    if items.is_empty() {
+        return Err(eyre!(
+            "No torrent provide and no downloads founds in {}",
+            metadata_path.display()
+        ));
+    }
+
+    let mut terminal = ratatui::init();
+    let result = run_selection_menu(&mut terminal, items, metadata_path, download_root)?;
+    ratatui::restore();
+    Ok(result)
+}
+
+struct SelectionState {
+    items: Vec<(String, String)>,
+    selected_index: usize,
+    should_quit: bool,
+    selected_hash: Option<String>,
+    delete_pending: bool,
+    pending_delete_index: Option<usize>,
+    metadata_path: PathBuf,
+    download_root: PathBuf,
+}
+
+pub fn run_selection_menu(
+    terminal: &mut DefaultTerminal,
+    items: Vec<(String, String)>,
+    metadata_path: PathBuf,
+    download_root: PathBuf,
+) -> EyreResult<Option<String>> {
+    let mut state = SelectionState {
+        items,
+        selected_index: 0,
+        should_quit: false,
+        selected_hash: None,
+        delete_pending: false,
+        pending_delete_index: None,
+        metadata_path,
+        download_root,
+    };
+
+    while !state.should_quit {
+        terminal.draw(|f| draw_selection(f, &state))?;
+        handle_selection_events(&mut state)?;
+    }
+
+    Ok(state.selected_hash)
+}
+
+fn draw_selection(frame: &mut Frame, state: &SelectionState) {
+    let area = frame.area();
+    let [list_area, help_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(area);
+
+    let list_items: Vec<ListItem> = state
+        .items
+        .iter()
+        .map(|(_, name)| ListItem::new(name.as_str()))
+        .collect();
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected_index));
+
+    let list = List::new(list_items)
+        .block(Block::bordered().title("Select a torrent"))
+        .highlight_style(Style::new().bg(Color::Yellow).fg(Color::Black))
+        .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, list_area, &mut list_state);
+
+    let help_text = if state.delete_pending {
+        format!(
+            "Delete '{}'? (y/n)",
+            state.items[state.pending_delete_index.unwrap_or(state.selected_index)].1
+        )
+    } else {
+        "↑/↓: navigate, Enter: select, d: delete, q: quit".to_string()
+    };
+
+    let help = Paragraph::new(help_text)
+        .block(Block::bordered())
+        .alignment(Alignment::Center);
+    frame.render_widget(help, help_area);
+}
+
+fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
+    if event::poll(Duration::from_millis(16))?
+        && let Event::Key(key) = event::read()?
+        && key.kind == KeyEventKind::Press
+    {
+        if state.delete_pending {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let idx = state.pending_delete_index.unwrap_or(state.selected_index);
+                    let (hash, name) = &state.items[idx];
+
+                    let base_name = if name.is_empty() {
+                        hash.as_str()
+                    } else {
+                        name.as_str()
+                    };
+                    let download_root = &state.download_root;
+
+                    let file_path = download_root.join(base_name);
+                    if file_path.exists() && file_path.is_file() {
+                        if let Err(e) = std::fs::remove_file(&file_path) {
+                            log::error!("Failed to delete file {}: {}", file_path.display(), e);
+                        } else {
+                            log::info!("Deleted file: {}", file_path.display());
+                        }
+                    }
+
+                    let dir_path = download_root.join(base_name);
+                    if dir_path.exists() && dir_path.is_dir() {
+                        if let Err(e) = std::fs::remove_dir_all(&dir_path) {
+                            log::error!("Failed to delete directory {}: {}", dir_path.display(), e);
+                        } else {
+                            log::info!("Deleted directory: {}", dir_path.display());
+                        }
+                    }
+
+                    let metadata_file = state.metadata_path.join(hash);
+                    if let Err(e) = std::fs::remove_file(&metadata_file) {
+                        log::error!(
+                            "Failed to delete metadata file {}: {}",
+                            metadata_file.display(),
+                            e
+                        );
+                    } else {
+                        log::info!("Deleted metadata file: {}", metadata_file.display());
+                    }
+
+                    state.items.remove(idx);
+
+                    if state.selected_index >= state.items.len() {
+                        state.selected_index = state.items.len().saturating_sub(1);
+                    }
+
+                    state.delete_pending = false;
+                    state.pending_delete_index = None;
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    state.delete_pending = false;
+                    state.pending_delete_index = None;
+                }
+                _ => {}
+            }
+        } else {
+            match key.code {
+                KeyCode::Up => {
+                    if state.selected_index > 0 {
+                        state.selected_index -= 1;
+                    }
+                }
+                KeyCode::Down => {
+                    if state.selected_index + 1 < state.items.len() {
+                        state.selected_index += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    let (hash, _) = state.items[state.selected_index].clone();
+                    state.selected_hash = Some(hash);
+                    state.should_quit = true;
+                }
+                KeyCode::Char('d') | KeyCode::Char('D') => {
+                    state.delete_pending = true;
+                    state.pending_delete_index = Some(state.selected_index);
+                }
+                KeyCode::Char('q') => {
+                    state.should_quit = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
 }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -5,7 +5,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use color_eyre::eyre::{Result as EyreResult, eyre};
+use clap::CommandFactory;
+use color_eyre::eyre::Result as EyreResult;
 use heapless::HistoryBuf;
 use human_bytes::human_bytes;
 use ratatui::{
@@ -22,7 +23,7 @@ use ratatui::{
 };
 use vortex_bittorrent::MetadataProgress;
 
-use crate::app::AppState;
+use crate::{Cli, app::AppState};
 
 fn download_style() -> Style {
     Style::default().fg(Color::Green)
@@ -387,10 +388,9 @@ pub fn select_torrent(
     }
 
     if items.is_empty() {
-        return Err(eyre!(
-            "No torrent provide and no downloads founds in {}",
-            metadata_path.display()
-        ));
+        Cli::command().print_help().unwrap();
+        println!();
+        return Ok(None);
     }
 
     let mut terminal = ratatui::init();


### PR DESCRIPTION
I Adds a selection menu for already started/downloaded torrents during startup so old torrents can easily be resumed.
Changes

    Metadata files are now stored in download_folder/metadata/ instead of directly in the download root.

    When no torrent arguments (--info-hash, --magnet-link, --torrent-file) are provided, a TUI popup lists all existing torrents from the metadata folder.

    Selecting a torrent starts the client with that torrent (same as providing --info-hash).

    In the selection popup, pressing d deletes the selected torrent – this removes both the metadata file and the downloaded data from the download root.

Notes

    I haven't written tests for the new UI flow. I'm not very experienced with testing TUI code, so any guidance on how to test this would be appreciated.

Please let me know if anything needs adjustment.

Closes #118