### PR TITLE
fix: correct subpiece slice bounds for non-power-of-2 piece lengths

### DIFF
--- a/bittorrent/src/buf_pool.rs
+++ b/bittorrent/src/buf_pool.rs
@@ -20,7 +20,10 @@ pub struct Buffer {
 
 impl Drop for Buffer {
     fn drop(&mut self) {
-        if self.inner.is_some() && self.pool_alive.load(std::sync::atomic::Ordering::Acquire) {
+        if self.inner.is_some()
+            && self.pool_alive.load(std::sync::atomic::Ordering::Acquire)
+            && !std::thread::panicking()
+        {
             panic!("Buffer must be returned to the pool before being dropped!");
         }
     }

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1026,11 +1026,9 @@ impl<'scope, 'state: 'scope> EventLoop {
                     // and it completing. That's fine
                     if let Some(connection) = self.connections.get_mut(connection_idx) {
                         let start_idx = piece_offset as usize;
-                        let end_idx = start_idx
-                            + state
-                                .piece_selector
-                                .piece_len(piece_idx)
-                                .min(SUBPIECE_SIZE as u32) as usize;
+                        let piece_len = state.piece_selector.piece_len(piece_idx) as usize;
+                        let end_idx =
+                            (start_idx + SUBPIECE_SIZE as usize).min(piece_len);
                         connection.send_piece(
                             piece_idx,
                             piece_offset,

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1027,8 +1027,7 @@ impl<'scope, 'state: 'scope> EventLoop {
                     if let Some(connection) = self.connections.get_mut(connection_idx) {
                         let start_idx = piece_offset as usize;
                         let piece_len = state.piece_selector.piece_len(piece_idx) as usize;
-                        let end_idx =
-                            (start_idx + SUBPIECE_SIZE as usize).min(piece_len);
+                        let end_idx = (start_idx + SUBPIECE_SIZE as usize).min(piece_len);
                         connection.send_piece(
                             piece_idx,
                             piece_offset,


### PR DESCRIPTION
When `piece_length` from torrent metadata is not a multiple of `SUBPIECE_SIZE` (16384), the last subpiece of every non-last piece is shorter than 16384 bytes. The disk read completion handler computed `end_idx` as `piece_offset + piece_len.min(SUBPIECE_SIZE)`, which always resolved to `piece_offset + 16384` — overflowing the buffer for that final subpiece.

Example from [monsoon](https://git.lair.cafe/monsoon/monsoon) crash (piece_length = 1,986,560 = 121 × 16384 + 4096):
- Peer requests `(begin=1982464, length=4096)` — valid per `is_valid_piece_req`
- `end_idx` = 1,982,464 + 16,384 = 1,998,848 > buffer length 1,986,560
- Panic at `event_loop.rs:1039`, then double-panic in `Buffer::drop` → process abort

**Changes:**

1. **event_loop.rs** — Fix `end_idx` to `(start_idx + SUBPIECE_SIZE).min(piece_len)`, capping the slice at the actual piece boundary.

2. **buf_pool.rs** — Guard `Buffer::drop` with `!std::thread::panicking()` to prevent secondary panics during unwind. Matches the existing `BufferRing::drop` pattern from PR #95.