### PR TITLE
fix: Expand piece request validation

### DIFF
--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -605,15 +605,28 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     #[inline]
-    fn is_valid_piece_req(&self, index: i32, begin: i32, length: i32, num_pieces: i32) -> bool {
-        index >= 0 && index <= num_pieces && begin % SUBPIECE_SIZE == 0 && length <= SUBPIECE_SIZE
+    fn is_valid_piece_req(
+        &self,
+        index: i32,
+        begin: i32,
+        length: i32,
+        num_pieces: i32,
+        piece_len: u32,
+    ) -> bool {
+        let begin = begin as u32;
+        index >= 0
+            && index <= num_pieces
+            && begin.is_multiple_of(SUBPIECE_SIZE as u32)
+            && length <= SUBPIECE_SIZE
+            && begin + length as u32 <= piece_len
     }
 
     #[inline]
     fn is_valid_piece(&self, index: i32, begin: i32, data_len: usize, num_pieces: usize) -> bool {
+        let begin = begin as u32;
         index >= 0
             && index <= num_pieces as i32
-            && begin % SUBPIECE_SIZE == 0
+            && begin.is_multiple_of(SUBPIECE_SIZE as u32)
             && data_len <= SUBPIECE_SIZE as usize
     }
 
@@ -905,11 +918,13 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     let Some(torrent_state) = state_ref.state() else {
                         return false;
                     };
+                    let piece_len = torrent_state.piece_selector.piece_len(index);
                     if !self.is_valid_piece_req(
                         index,
                         begin,
                         length,
                         torrent_state.num_pieces() as i32,
+                        piece_len,
                     ) {
                         log::warn!(
                             "[Peer: {}] Piece request ignored/rejected, invalid request",
@@ -942,7 +957,6 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                             // TODO: cache the entire piece and store it with some TTL
                             // to avoid reading the entire piece for each subpiece request
                             let data = torrent_state.piece_buffer_pool.get_buffer();
-                            let piece_len = torrent_state.piece_selector.piece_len(index);
                             torrent_state.file_store.queue_piece_disk_operation(
                                 index,
                                 data,
@@ -985,8 +999,14 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     );
                     return;
                 };
-                if !self.is_valid_piece_req(index, begin, length, torrent_state.num_pieces() as i32)
-                {
+                let piece_len = torrent_state.piece_selector.piece_len(index);
+                if !self.is_valid_piece_req(
+                    index,
+                    begin,
+                    length,
+                    torrent_state.num_pieces() as i32,
+                    piece_len,
+                ) {
                     log::error!(
                         "[Peer: {}] Piece Reject request was invalid, index={index} begin={begin} length={length}",
                         self.peer_id

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -4596,3 +4596,107 @@ fn seeding_quota_complete_peers_deprioritized() {
         assert_eq!(torrent_state.num_unchoked as usize, 2);
     });
 }
+
+#[test]
+fn request_rejected_when_begin_plus_length_exceeds_piece_len() {
+    // piece_length = SUBPIECE_SIZE * 2 in the seeding test setup
+    let mut download_state = setup_seeding_test();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+        state_ref.state().unwrap().piece_buffer_pool.stop_tracking();
+        let mut pending_disk_operations: Vec<DiskOp> = Vec::new();
+        let mut connections = SlotMap::<ConnectionId, PeerConnection>::with_key();
+        let key = connections.insert_with_key(|k| generate_peer(true, k));
+
+        // Setup: peer has no pieces and is interested
+        connections[key].handle_message(
+            PeerMessage::HaveNone,
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        connections[key].handle_message(
+            PeerMessage::Interested,
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+
+        // Valid request: begin=0, length=SUBPIECE_SIZE within piece_len (SUBPIECE_SIZE * 2)
+        connections[key].handle_message(
+            PeerMessage::Request {
+                index: 0,
+                begin: 0,
+                length: SUBPIECE_SIZE,
+            },
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        // Should trigger disk reads (valid request accepted)
+        assert!(
+            !pending_disk_operations.is_empty(),
+            "Valid request should queue disk operations"
+        );
+
+        pending_disk_operations.clear();
+        connections[key].outgoing_msgs_buffer.clear();
+
+        // Invalid request: length=SUBPIECE_SIZE+1 exceeds subpiece size
+        connections[key].handle_message(
+            PeerMessage::Request {
+                index: 0,
+                begin: 0,
+                length: SUBPIECE_SIZE + 1,
+            },
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        // Should NOT trigger any disk reads (invalid request rejected)
+        assert!(
+            pending_disk_operations.is_empty(),
+            "Request exceeding piece boundary should be rejected"
+        );
+        // With fast_ext enabled, a RejectRequest should be queued
+        assert!(
+            connections[key]
+                .outgoing_msgs_buffer
+                .contains(&PeerMessage::RejectRequest {
+                    index: 0,
+                    begin: 0,
+                    length: SUBPIECE_SIZE + 1,
+                }),
+            "Should queue RejectRequest for invalid request when fast_ext is enabled"
+        );
+
+        connections[key].outgoing_msgs_buffer.clear();
+
+        // Invalid request: begin at the very end of the piece, any nonzero length overflows
+        connections[key].handle_message(
+            PeerMessage::Request {
+                index: 0,
+                begin: SUBPIECE_SIZE * 2,
+                length: 123,
+            },
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        assert!(
+            pending_disk_operations.is_empty(),
+            "Request at piece boundary should be rejected"
+        );
+        assert!(
+            connections[key]
+                .outgoing_msgs_buffer
+                .contains(&PeerMessage::RejectRequest {
+                    index: 0,
+                    begin: SUBPIECE_SIZE * 2,
+                    length: 123,
+                }),
+            "Should queue RejectRequest for request at piece boundary"
+        );
+    });
+}


### PR DESCRIPTION
As seen in #124 there are panics in the disk read logic that can happen due to invalid piece requests. These should be filtered out when received and not propagated to the file i/o code at all.

Hopefully that also fixes the crash seen by @grenade