### PR TITLE
feat: Implement torrent selection menu and update application state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -142,9 +142,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -152,14 +152,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -206,9 +207,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -264,9 +265,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -276,9 +277,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "castaway"
@@ -291,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -326,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -336,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -355,7 +356,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -487,18 +488,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -506,18 +507,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -525,7 +526,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -577,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -598,7 +599,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -627,7 +628,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -638,7 +639,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -649,9 +650,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -659,15 +660,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -699,7 +699,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1215,15 +1215,15 @@ checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1327,16 +1327,16 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "io-uring"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "libc",
 ]
@@ -1379,9 +1379,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1393,22 +1393,22 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1451,7 +1451,7 @@ dependencies = [
  "num_cpus",
  "percent-encoding",
  "rayon",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "thiserror 1.0.69",
 ]
 
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1508,7 +1508,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1559,9 +1559,9 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -1675,7 +1675,7 @@ dependencies = [
  "ordered-float 5.3.0",
  "quanta",
  "radix_trie",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1732,7 +1732,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1772,7 +1772,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1915,9 +1915,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1935,25 +1935,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1983,7 +1982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1996,7 +1995,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2013,6 +2012,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -2042,28 +2047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2129,18 +2112,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2148,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -2199,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -2228,13 +2211,13 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru 0.18.1",
  "palette",
  "serde",
  "strum",
@@ -2293,7 +2276,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -2313,7 +2296,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2342,7 +2325,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2358,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2370,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2401,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc_version"
@@ -2420,7 +2403,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2429,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2455,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2476,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2513,7 +2496,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2583,7 +2566,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2597,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2732,9 +2715,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2742,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -2785,7 +2768,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2807,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2828,7 +2811,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -2864,7 +2847,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2924,7 +2907,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2935,23 +2918,23 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "libc",
@@ -3007,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3040,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower-service"
@@ -3069,7 +3052,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3172,9 +3155,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -3212,7 +3195,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rayon",
  "serde",
  "sha1 0.11.0",
@@ -3312,7 +3295,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3528,9 +3511,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -3549,22 +3532,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/bittorrent/src/peer_comm/peer_protocol.rs
+++ b/bittorrent/src/peer_comm/peer_protocol.rs
@@ -90,7 +90,7 @@ const fn build_peer_id_prefix(major: &'static str, minor: &'static str) -> [u8; 
     let major_bytes = major.as_bytes();
     let minor_bytes = minor.as_bytes();
 
-    let mut prefix = [b'-', b'V', b'T', b'0', b'0', b'0', b'0', b'-'];
+    let mut prefix = *b"-VT0000-";
 
     // Parse major version (supports 0-99)
     match major_bytes.len() {

--- a/bittorrent/src/torrent.rs
+++ b/bittorrent/src/torrent.rs
@@ -385,7 +385,7 @@ impl InitializedState {
                     peer.pending_disconnect = Some(DisconnectReason::RedundantConnection);
                 }
                 // Notify all extensions that the torrent completed
-                for (_, extension) in peer.extensions.iter_mut() {
+                for extension in peer.extensions.values_mut() {
                     extension.on_torrent_complete(&mut peer.outgoing_msgs_buffer);
                 }
             }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,7 +1,6 @@
 //! Application state and lifecycle management.
 
 use std::{
-    io,
     path::PathBuf,
     sync::{
         Arc,
@@ -11,18 +10,20 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
+use color_eyre::eyre::Context;
 use crossbeam_channel::Sender;
 use heapless::{HistoryBuf, spsc::Consumer};
 use ratatui::{
     DefaultTerminal, Frame,
     crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    widgets::ListState,
 };
-use vortex_bittorrent::{Command, MetadataProgress, TorrentEvent};
+use vortex_bittorrent::{Command, MetadataProgress, State, TorrentEvent};
 
-use crate::ui::{self, Time};
+use crate::ui::Time;
 
+#[allow(clippy::large_enum_variant)]
 /// Current state of the torrent application.
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AppState {
     /// Downloading torrent metadata from peers
     DownloadingMetadata,
@@ -37,10 +38,14 @@ pub enum AppState {
         // Keep track of the last simulated data to the graph
         last_simulated_update: Instant,
     },
+    /// A torrent has been picked but its threads haven't been started yet.
+    SelectedTorrent { state: State },
+    /// Picking among the torrents with stored metadata
     SelectingTorrent {
         items: Vec<(String, String)>,
-        selected_index: usize,
-        delete_pending: bool,
+        /// Owns both the selected index and the scroll offset
+        list_state: ListState,
+        /// The item awaiting delete confirmation, if any
         pending_delete_index: Option<usize>,
         metadata_path: PathBuf,
         download_root: PathBuf,
@@ -49,6 +54,7 @@ pub enum AppState {
 
 pub const METADATA_DIR: &str = "metadata";
 
+#[derive(Clone)]
 pub enum Metadata {
     /// Full metadata is available
     Full(Box<lava_torrent::torrent::v1::Torrent>),
@@ -87,6 +93,17 @@ pub struct VortexApp<'queue, F> {
 }
 
 impl<'queue, F> VortexApp<'queue, F> {
+
+    fn started_state(state: &State, metadata: &Metadata) -> AppState {
+        if state.is_complete() {
+            AppState::Seeding
+        } else if metadata.is_none() {
+            AppState::DownloadingMetadata
+        } else {
+            AppState::Downloading
+        }
+    }
+
     pub fn shutdown(&mut self) {
         let _ = self.setup.cmd_tx.send(Command::Stop);
         let _ = self.setup.shutdown_signal_tx.send(());
@@ -105,32 +122,26 @@ pub struct AppSetup<'queue> {
     pub metadata: Metadata,
     /// Root directory for downloads
     pub root: PathBuf,
-    /// If the torrent is already downloaded
-    pub is_complete: bool,
     /// Flag stating if the dht should pause or not
     pub pause_dht: Arc<AtomicBool>,
+    /// Config used
+    pub config: vortex_bittorrent::Config,
 }
 
-impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
-    pub fn new(setup: AppSetup<'queue>, spawn_torrent_threads: F) -> Self {
-        let state = if let Some((items, metadata_path, download_root)) = initial_selection {
-            AppState::SelectingTorrent {
-                items,
-                selected_index: 0,
-                delete_pending: false,
-                pending_delete_index: None,
-                metadata_path,
-                download_root,
-            }
-        } else if is_complete {
-            AppState::Seeding
-        } else if setup.metadata.is_none() {
-            AppState::DownloadingMetadata
+impl<'queue, F: FnOnce(State) -> color_eyre::Result<()>> VortexApp<'queue, F> {
+    pub fn new(
+        setup: AppSetup<'queue>,
+        mut app_state: AppState,
+        spawn_torrent_threads: F,
+    ) -> color_eyre::Result<Self> {
+        let spawn_torrent_threads = if let AppState::SelectedTorrent { state } = app_state {
+            app_state = Self::started_state(&state, &setup.metadata);
+            spawn_torrent_threads(state)?;
+            None
         } else {
-            AppState::Downloading
+            Some(spawn_torrent_threads)
         };
-
-        Self {
+        Ok(Self {
             setup,
             should_exit: false,
             start_time: Instant::now(),
@@ -140,13 +151,12 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
             num_connections: 0,
             best_metadata_progress: Default::default(),
             time_field: Time::StartedAt(SystemTime::now()),
-            spawn_torrent_threads: Some(spawn_torrent_threads),
-            state,
-            selected_hash: None,
-        }
+            spawn_torrent_threads,
+            state: app_state,
+        })
     }
 
-    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
+    pub fn run(&mut self, mut terminal: DefaultTerminal) -> color_eyre::Result<()> {
         while !self.should_exit {
             terminal.draw(|frame| self.draw(frame))?;
             self.handle_events()?;
@@ -155,26 +165,41 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
     }
 
     fn draw(&mut self, frame: &mut Frame) {
-        if let AppState::SelectingTorrent { .. } = self.state {
-            self.draw_selection(frame);
-        } else {
-            frame.render_widget(self, frame.area());
-        }
+        frame.render_widget(self, frame.area());
     }
 
-    pub fn handle_events(&mut self) -> io::Result<()> {
-        // Spawn the torrent threads the first time we reach the event handler.
-        // Keeping this here (rather than before the loop) means the spawning
-        // lives alongside the rest of the event handling and can later be gated
-        // on application state.
-        if let Some(spawn_torrent_threads) = self.spawn_torrent_threads.take() {
-            spawn_torrent_threads();
+    pub fn handle_events(&mut self) -> color_eyre::Result<()> {
+        match &mut self.state {
+            AppState::Paused {
+                last_simulated_update,
+                ..
+            } if last_simulated_update.elapsed() >= Duration::from_secs(1) => {
+                // Simulate data so the graph isn't static
+                let curr_time = self.start_time.elapsed().as_secs_f64();
+                self.total_download_throughput.write((curr_time, 0.0));
+                self.total_upload_throughput.write((curr_time, 0.0));
+                *last_simulated_update = Instant::now();
+            }
+            AppState::SelectedTorrent { state } => {
+                // Start torrent threads once a torrent has been selected
+                let spawn_torrent_threads = self
+                    .spawn_torrent_threads
+                    .take()
+                    .expect("Must only select torrent once");
+                let new_state = Self::started_state(state, &self.setup.metadata);
+                let AppState::SelectedTorrent { state } =
+                    std::mem::replace(&mut self.state, new_state)
+                else {
+                    unreachable!();
+                };
+                spawn_torrent_threads(state)?;
+            }
+            // No torrent is running while the menu is up, so there are no torrent
+            // events to drain and the keys mean something else entirely.
+            AppState::SelectingTorrent { .. } => return self.handle_selection_events(),
+            _ => {}
         }
         while let Some(event) = self.setup.event_rc.dequeue() {
-        // if matches!(self.state, AppState::SelectingTorrent { .. }) {
-        //     return self.handle_selection_events();
-        // }
-        while let Some(event) = self.event_rc.dequeue() {
             match event {
                 TorrentEvent::TorrentComplete => {
                     let download_time = match self.time_field {
@@ -256,19 +281,6 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
             }
         }
 
-        match &mut self.state {
-            AppState::Paused {
-                last_simulated_update,
-                ..
-            } if last_simulated_update.elapsed() >= Duration::from_secs(1) => {
-                // Simulate data so the graph isn't static
-                let curr_time = self.start_time.elapsed().as_secs_f64();
-                self.total_download_throughput.write((curr_time, 0.0));
-                self.total_upload_throughput.write((curr_time, 0.0));
-                *last_simulated_update = Instant::now();
-            }
-            _ => {}
-        }
         if event::poll(Duration::from_millis(16))? {
             match event::read()? {
                 // it's important to check that the event is a key press event as
@@ -296,42 +308,24 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
         }
     }
 
-    fn draw_selection(&self, frame: &mut Frame) {
-        if let AppState::SelectingTorrent {
-            items,
-            selected_index,
-            delete_pending,
-            pending_delete_index,
-            ..
-        } = &self.state
-        {
-            let data = ui::SelectionData {
-                items: items.as_slice(),
-                selected_index: *selected_index,
-                delete_pending: *delete_pending,
-                pending_delete_index: *pending_delete_index,
-            };
-            ui::draw_torrent_selection(frame, frame.area(), &data);
-        }
-    }
-
-    fn handle_selection_events(&mut self) -> io::Result<()> {
+    fn handle_selection_events(&mut self) -> color_eyre::Result<()> {
         if event::poll(Duration::from_millis(16))?
             && let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
             && let AppState::SelectingTorrent {
                 items,
-                selected_index,
-                delete_pending,
+                list_state,
                 pending_delete_index,
                 metadata_path,
                 download_root,
             } = &mut self.state
         {
-            if *delete_pending {
+            // The list clamps the selection when rendering, so it's only ever out of
+            // range between a keypress and the next draw.
+            let selected = list_state.selected().filter(|idx| *idx < items.len());
+            if let Some(idx) = *pending_delete_index {
                 match key.code {
                     KeyCode::Char('y') | KeyCode::Char('Y') => {
-                        let idx = pending_delete_index.unwrap_or(*selected_index);
                         let (hash, name) = &items[idx];
 
                         let base_name = if name.is_empty() {
@@ -352,49 +346,40 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
                         let _ = std::fs::remove_file(&metadata_file);
 
                         items.remove(idx);
+                        *pending_delete_index = None;
 
                         if items.is_empty() {
+                            // Not much to do here
                             self.should_exit = true;
-                            return Ok(());
                         }
-
-                        if *selected_index >= items.len() {
-                            *selected_index = items.len().saturating_sub(1);
-                        }
-
-                        *delete_pending = false;
-                        *pending_delete_index = None;
                     }
                     KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                        *delete_pending = false;
                         *pending_delete_index = None;
                     }
                     _ => {}
                 }
             } else {
                 match key.code {
-                    KeyCode::Up => {
-                        if *selected_index > 0 {
-                            *selected_index -= 1;
-                        }
-                    }
-                    KeyCode::Down => {
-                        if *selected_index + 1 < items.len() {
-                            *selected_index += 1;
-                        }
-                    }
+                    KeyCode::Up => list_state.select_previous(),
+                    KeyCode::Down => list_state.select_next(),
                     KeyCode::Enter => {
-                        if !items.is_empty() {
-                            let (hash, _) = items[*selected_index].clone();
-                            self.selected_hash = Some(hash);
-                            self.should_exit = true;
+                        if let Some(idx) = selected {
+                            let (hash, _) = items[idx].clone();
+                            let metadata = lava_torrent::torrent::v1::Torrent::read_from_file(
+                                self.setup.root.join(METADATA_DIR).join(hash.to_lowercase()),
+                            )
+                            .context("Failed to open metadata file")?;
+                            let state = State::from_metadata_and_root(
+                                metadata.clone(),
+                                self.setup.root.clone(),
+                                self.setup.config,
+                            )?;
+                            self.setup.metadata = Metadata::Full(Box::new(metadata));
+                            self.state = AppState::SelectedTorrent { state };
                         }
                     }
                     KeyCode::Char('d') | KeyCode::Char('D') => {
-                        if !items.is_empty() {
-                            *delete_pending = true;
-                            *pending_delete_index = Some(*selected_index);
-                        }
+                        *pending_delete_index = selected;
                     }
                     KeyCode::Char('q') => {
                         self.should_exit = true;

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -19,10 +19,10 @@ use ratatui::{
 };
 use vortex_bittorrent::{Command, MetadataProgress, TorrentEvent};
 
-use crate::ui::Time;
+use crate::ui::{self, Time};
 
 /// Current state of the torrent application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AppState {
     /// Downloading torrent metadata from peers
     DownloadingMetadata,
@@ -36,6 +36,14 @@ pub enum AppState {
         was_seeding: bool,
         // Keep track of the last simulated data to the graph
         last_simulated_update: Instant,
+    },
+    SelectingTorrent {
+        items: Vec<(String, String)>,
+        selected_index: usize,
+        delete_pending: bool,
+        pending_delete_index: Option<usize>,
+        metadata_path: PathBuf,
+        download_root: PathBuf,
     },
 }
 
@@ -105,7 +113,16 @@ pub struct AppSetup<'queue> {
 
 impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
     pub fn new(setup: AppSetup<'queue>, spawn_torrent_threads: F) -> Self {
-        let state = if setup.is_complete {
+        let state = if let Some((items, metadata_path, download_root)) = initial_selection {
+            AppState::SelectingTorrent {
+                items,
+                selected_index: 0,
+                delete_pending: false,
+                pending_delete_index: None,
+                metadata_path,
+                download_root,
+            }
+        } else if is_complete {
             AppState::Seeding
         } else if setup.metadata.is_none() {
             AppState::DownloadingMetadata
@@ -125,10 +142,11 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
             time_field: Time::StartedAt(SystemTime::now()),
             spawn_torrent_threads: Some(spawn_torrent_threads),
             state,
+            selected_hash: None,
         }
     }
 
-    pub fn run(&mut self, mut terminal: DefaultTerminal) -> color_eyre::Result<()> {
+    pub fn run(&mut self, terminal: &mut DefaultTerminal) -> color_eyre::Result<()> {
         while !self.should_exit {
             terminal.draw(|frame| self.draw(frame))?;
             self.handle_events()?;
@@ -137,7 +155,11 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
     }
 
     fn draw(&mut self, frame: &mut Frame) {
-        frame.render_widget(self, frame.area());
+        if let AppState::SelectingTorrent { .. } = self.state {
+            self.draw_selection(frame);
+        } else {
+            frame.render_widget(self, frame.area());
+        }
     }
 
     pub fn handle_events(&mut self) -> io::Result<()> {
@@ -149,6 +171,10 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
             spawn_torrent_threads();
         }
         while let Some(event) = self.setup.event_rc.dequeue() {
+        // if matches!(self.state, AppState::SelectingTorrent { .. }) {
+        //     return self.handle_selection_events();
+        // }
+        while let Some(event) = self.event_rc.dequeue() {
             match event {
                 TorrentEvent::TorrentComplete => {
                     let download_time = match self.time_field {
@@ -268,6 +294,116 @@ impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
             }
             _ => {}
         }
+    }
+
+    fn draw_selection(&self, frame: &mut Frame) {
+        if let AppState::SelectingTorrent {
+            items,
+            selected_index,
+            delete_pending,
+            pending_delete_index,
+            ..
+        } = &self.state
+        {
+            let data = ui::SelectionData {
+                items: items.as_slice(),
+                selected_index: *selected_index,
+                delete_pending: *delete_pending,
+                pending_delete_index: *pending_delete_index,
+            };
+            ui::draw_torrent_selection(frame, frame.area(), &data);
+        }
+    }
+
+    fn handle_selection_events(&mut self) -> io::Result<()> {
+        if event::poll(Duration::from_millis(16))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && let AppState::SelectingTorrent {
+                items,
+                selected_index,
+                delete_pending,
+                pending_delete_index,
+                metadata_path,
+                download_root,
+            } = &mut self.state
+        {
+            if *delete_pending {
+                match key.code {
+                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                        let idx = pending_delete_index.unwrap_or(*selected_index);
+                        let (hash, name) = &items[idx];
+
+                        let base_name = if name.is_empty() {
+                            hash.as_str()
+                        } else {
+                            name.as_str()
+                        };
+                        let file_path = download_root.join(base_name);
+                        if file_path.exists() {
+                            if file_path.is_file() {
+                                let _ = std::fs::remove_file(&file_path);
+                            } else if file_path.is_dir() {
+                                let _ = std::fs::remove_dir_all(&file_path);
+                            }
+                        }
+
+                        let metadata_file = metadata_path.join(hash);
+                        let _ = std::fs::remove_file(&metadata_file);
+
+                        items.remove(idx);
+
+                        if items.is_empty() {
+                            self.should_exit = true;
+                            return Ok(());
+                        }
+
+                        if *selected_index >= items.len() {
+                            *selected_index = items.len().saturating_sub(1);
+                        }
+
+                        *delete_pending = false;
+                        *pending_delete_index = None;
+                    }
+                    KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                        *delete_pending = false;
+                        *pending_delete_index = None;
+                    }
+                    _ => {}
+                }
+            } else {
+                match key.code {
+                    KeyCode::Up => {
+                        if *selected_index > 0 {
+                            *selected_index -= 1;
+                        }
+                    }
+                    KeyCode::Down => {
+                        if *selected_index + 1 < items.len() {
+                            *selected_index += 1;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if !items.is_empty() {
+                            let (hash, _) = items[*selected_index].clone();
+                            self.selected_hash = Some(hash);
+                            self.should_exit = true;
+                        }
+                    }
+                    KeyCode::Char('d') | KeyCode::Char('D') => {
+                        if !items.is_empty() {
+                            *delete_pending = true;
+                            *pending_delete_index = Some(*selected_index);
+                        }
+                    }
+                    KeyCode::Char('q') => {
+                        self.should_exit = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -93,7 +93,6 @@ pub struct VortexApp<'queue, F> {
 }
 
 impl<'queue, F> VortexApp<'queue, F> {
-
     fn started_state(state: &State, metadata: &Metadata) -> AppState {
         if state.is_complete() {
             AppState::Seeding

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use mainline::{Dht, Id};
 use ratatui::{
     layout::{Constraint, Layout},
     prelude::{Buffer, Rect},
-    widgets::Widget,
+    widgets::{ListState, StatefulWidget, Widget},
 };
 use vortex_bittorrent::{Command, PeerId, State, Torrent, TorrentEvent};
 
@@ -31,8 +31,8 @@ mod ui;
 
 use app::{AppState, Metadata, VortexApp};
 use ui::{
-    Footer, InfoData, InfoPanel, ProgressBar, ProgressState, ThroughputData, ThroughputGraph,
-    extract_throughput_data,
+    Footer, InfoData, InfoPanel, ProgressBar, ProgressState, SelectionData, ThroughputData,
+    ThroughputGraph, extract_throughput_data,
 };
 
 use mimalloc::MiMalloc;
@@ -319,84 +319,7 @@ fn main() -> color_eyre::Result<()> {
     let bt_config = vortex_config.bittorrent;
     let root = paths.download_folder.clone();
 
-    let needs_selection = cli.torrent_info.info_hash.is_none()
-        && cli.torrent_info.magnet_link.is_none()
-        && cli.torrent_info.torrent_file.is_none();
-
-    let selection_data = if needs_selection {
-        let metadata_path = paths.download_folder.join(METADATA_DIR);
-        let mut items = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(&metadata_path) {
-            for entry in entries.flatten() {
-                let file_name = entry.file_name();
-                let name_str = file_name.to_string_lossy();
-                if name_str.len() == 40 && name_str.chars().all(|c| c.is_ascii_hexdigit()) {
-                    let hash = name_str.to_string();
-                    let display_name =
-                        lava_torrent::torrent::v1::Torrent::read_from_file(entry.path())
-                            .ok()
-                            .map(|t| t.name)
-                            .unwrap_or_else(|| hash.clone());
-                    items.push((hash, display_name));
-                }
-            }
-        }
-        if items.is_empty() {
-            Cli::command().print_help()?;
-            println!();
-            return Ok(());
-        }
-        Some((items, metadata_path, paths.download_folder.clone()))
-    } else {
-        None
-    };
-
-    let mut terminal = ratatui::init();
-
-    let selected_hash = if let Some((ref items, ref meta_path, ref down_root)) = selection_data {
-        let (cmd_tx, _) = std::sync::mpsc::sync_channel(1);
-        let mut event_q: Queue<TorrentEvent, 512> = heapless::spsc::Queue::new();
-        let (_, event_rc) = event_q.split();
-        let (shutdown_signal_tx, _) = bounded(1);
-        let dht_paused = Arc::new(AtomicBool::new(false));
-
-        let mut selection_app = VortexApp::new(
-            cmd_tx,
-            event_rc,
-            shutdown_signal_tx,
-            Metadata::None,
-            down_root.clone(),
-            false,
-            dht_paused,
-            Some((
-                items.to_vec(),
-                meta_path.to_path_buf(),
-                down_root.to_path_buf(),
-            )),
-        );
-
-        selection_app.run(&mut terminal)?;
-        selection_app.selected_hash.clone()
-    } else {
-        None
-    };
-
-    if selection_data.is_some() && selected_hash.is_none() {
-        ratatui::restore();
-        return Ok(());
-    }
-
-    let torrent_info = if let Some(hash) = selected_hash {
-        TorrentInfo {
-            info_hash: Some(hash),
-            magnet_link: None,
-            torrent_file: None,
-        }
-    } else {
-        cli.torrent_info
-    };
-
-    let (state, metadata) = match torrent_info {
+    let (app_state, initial_metadata) = match cli.torrent_info {
         TorrentInfo {
             info_hash: None,
             magnet_link: None,
@@ -408,11 +331,15 @@ fn main() -> color_eyre::Result<()> {
                 State::from_metadata_and_root(parsed_metadata.clone(), root.clone(), bt_config)
                     .wrap_err("Failed initialzing state")?;
 
-            (state, Metadata::Full(Box::new(parsed_metadata)))
+            (
+                AppState::SelectedTorrent { state },
+                Metadata::Full(Box::new(parsed_metadata)),
+            )
         }
         _ => {
             let mut magnet_name = None;
-            let info_hash_str = torrent_info
+            let info_hash_str = cli
+                .torrent_info
                 .magnet_link
                 .as_deref()
                 .map(|m| -> color_eyre::Result<String> {
@@ -421,45 +348,77 @@ fn main() -> color_eyre::Result<()> {
                     Ok(info.info_hash)
                 })
                 .transpose()?
-                .or_else(|| torrent_info.info_hash.clone());
-            let info_hash = if let Some(hash) = info_hash_str {
-                hash
-            } else {
-                Cli::command().print_help()?;
-                println!();
-                return Ok(());
-            };
-
-            match lava_torrent::torrent::v1::Torrent::read_from_file(
-                root.join(METADATA_DIR).join(info_hash.to_lowercase()),
-            ) {
-                Ok(metadata) => {
-                    let state =
-                        State::from_metadata_and_root(metadata.clone(), root.clone(), bt_config)?;
-                    (state, Metadata::Full(Box::new(metadata)))
-                }
-                Err(lava_torrent::LavaTorrentError::Io(io_err)) => {
-                    if io_err.kind() == ErrorKind::NotFound {
-                        let state = State::unstarted(
-                            decode_info_hash_hex(&info_hash).wrap_err("Invalid info hash")?,
+                .or_else(|| cli.torrent_info.info_hash.clone());
+            if let Some(info_hash) = info_hash_str {
+                match lava_torrent::torrent::v1::Torrent::read_from_file(
+                    root.join(METADATA_DIR).join(info_hash.to_lowercase()),
+                ) {
+                    Ok(metadata) => {
+                        let state = State::from_metadata_and_root(
+                            metadata.clone(),
                             root.clone(),
                             bt_config,
-                        );
-                        let meta_varient = match magnet_name {
-                            Some(name) => Metadata::Partial { name },
-                            None => Metadata::None,
-                        };
-                        (state, meta_varient)
-                    } else {
-                        return Err(eyre!("Failed looking for stored metadata {io_err}"));
+                        )?;
+                        (
+                            AppState::SelectedTorrent { state },
+                            Metadata::Full(Box::new(metadata)),
+                        )
+                    }
+                    Err(lava_torrent::LavaTorrentError::Io(io_err)) => {
+                        if io_err.kind() == ErrorKind::NotFound {
+                            let state = State::unstarted(
+                                decode_info_hash_hex(&info_hash).wrap_err("Invalid info hash")?,
+                                root.clone(),
+                                bt_config,
+                            );
+                            let meta_variant = match magnet_name {
+                                Some(name) => Metadata::Partial { name },
+                                None => Metadata::None,
+                            };
+                            (AppState::SelectedTorrent { state }, meta_variant)
+                        } else {
+                            return Err(eyre!("Failed looking for stored metadata {io_err}"));
+                        }
+                    }
+                    Err(err) => return Err(eyre!("Failed looking for stored metadata {err}")),
+                }
+            } else {
+                let metadata_path = paths.download_folder.join(METADATA_DIR);
+                let mut items = Vec::new();
+                if let Ok(entries) = std::fs::read_dir(&metadata_path) {
+                    for entry in entries.flatten() {
+                        let file_name = entry.file_name();
+                        let name_str = file_name.to_string_lossy();
+                        if name_str.len() == 40 && name_str.chars().all(|c| c.is_ascii_hexdigit()) {
+                            let hash = name_str.to_string();
+                            let display_name =
+                                lava_torrent::torrent::v1::Torrent::read_from_file(entry.path())
+                                    .ok()
+                                    .map(|t| t.name)
+                                    .unwrap_or_else(|| hash.clone());
+                            items.push((hash, display_name));
+                        }
                     }
                 }
-                Err(err) => return Err(eyre!("Failed looking for stored metadata {err}")),
+                if items.is_empty() {
+                    Cli::command().print_help()?;
+                    println!();
+                    return Ok(());
+                }
+                // Nothing is selected yet, so there's no metadata to show
+                (
+                    AppState::SelectingTorrent {
+                        items,
+                        list_state: ListState::default().with_selected(Some(0)),
+                        pending_delete_index: None,
+                        metadata_path,
+                        download_root: paths.download_folder.clone(),
+                    },
+                    Metadata::None,
+                )
             }
         }
     };
-
-    let info_hash_id = Id::from_bytes(state.info_hash()).wrap_err("Invalid info_hash")?;
 
     let mut event_q: Queue<TorrentEvent, 512> = heapless::spsc::Queue::new();
 
@@ -472,8 +431,6 @@ fn main() -> color_eyre::Result<()> {
 
     let port = listener.local_addr().unwrap().port();
     let id = PeerId::generate();
-    let is_complete = state.is_complete();
-    let mut torrent = Torrent::new(id, state);
     let (shutdown_signal_tx, shutdown_signal_rc) = bounded(1);
     let pause_dht = Arc::new(AtomicBool::new(false));
 
@@ -482,7 +439,9 @@ fn main() -> color_eyre::Result<()> {
         let cmd_tx_clone = cmd_tx.clone();
         let pause_dht_clone = Arc::clone(&pause_dht);
         // Use a closure to allow for spawning the torrent threads later in the cli lifecycle
-        let spawn_torrent_threads = move || {
+        let spawn_torrent_threads = move |state: State| -> color_eyre::Result<()> {
+            let info_hash_id = Id::from_bytes(state.info_hash()).wrap_err("Invalid info_hash")?;
+            let mut torrent = Torrent::new(id, state);
             s.spawn(move || {
                 torrent.start(event_tx, cmd_rc, listener).unwrap();
             });
@@ -498,19 +457,20 @@ fn main() -> color_eyre::Result<()> {
                 )
                 .expect("DHT thread failed")
             });
+            Ok(())
         };
 
         let setup = AppSetup {
             cmd_tx,
             event_rc,
             shutdown_signal_tx,
-            metadata,
+            metadata: initial_metadata,
             root,
-            is_complete,
             pause_dht,
+            config: bt_config,
         };
 
-        let mut app = VortexApp::new(setup, spawn_torrent_threads);
+        let mut app = VortexApp::new(setup, app_state, spawn_torrent_threads)?;
         let terminal = ratatui::init();
         let result = app.run(terminal);
         ratatui::restore();
@@ -520,6 +480,21 @@ fn main() -> color_eyre::Result<()> {
 
 impl<F> Widget for &mut VortexApp<'_, F> {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        if let AppState::SelectingTorrent {
+            items,
+            list_state,
+            pending_delete_index,
+            ..
+        } = &mut self.state
+        {
+            let data = SelectionData {
+                items,
+                pending_delete_index: *pending_delete_index,
+            };
+            StatefulWidget::render(data, area, buf, list_state);
+            return;
+        }
+
         let [progress_area, graph_area, info_area, footer_area] = Layout::vertical([
             Constraint::Length(4),
             Constraint::Fill(1),
@@ -572,7 +547,10 @@ impl<F> Widget for &mut VortexApp<'_, F> {
                     }
                 }
             }
-            AppState::SelectingTorrent { .. } => unreachable!(),
+            // Handled above, before the download layout is laid out
+            AppState::SelectingTorrent { .. } => return,
+            // Transitional state
+            AppState::SelectedTorrent { .. } => return,
         };
 
         ProgressBar::new(progress_state).render(progress_area, buf);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -319,17 +319,76 @@ fn main() -> color_eyre::Result<()> {
     let bt_config = vortex_config.bittorrent;
     let root = paths.download_folder.clone();
 
-    let torrent_info = if cli.torrent_info.info_hash.is_none()
+    let needs_selection = cli.torrent_info.info_hash.is_none()
         && cli.torrent_info.magnet_link.is_none()
-        && cli.torrent_info.torrent_file.is_none()
-    {
+        && cli.torrent_info.torrent_file.is_none();
+
+    let selection_data = if needs_selection {
         let metadata_path = paths.download_folder.join(METADATA_DIR);
-        let selected_hash = match ui::select_torrent(metadata_path, root.clone())? {
-            Some(hash) => hash,
-            None => return Ok(()),
-        };
+        let mut items = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&metadata_path) {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name();
+                let name_str = file_name.to_string_lossy();
+                if name_str.len() == 40 && name_str.chars().all(|c| c.is_ascii_hexdigit()) {
+                    let hash = name_str.to_string();
+                    let display_name =
+                        lava_torrent::torrent::v1::Torrent::read_from_file(entry.path())
+                            .ok()
+                            .map(|t| t.name)
+                            .unwrap_or_else(|| hash.clone());
+                    items.push((hash, display_name));
+                }
+            }
+        }
+        if items.is_empty() {
+            Cli::command().print_help()?;
+            println!();
+            return Ok(());
+        }
+        Some((items, metadata_path, paths.download_folder.clone()))
+    } else {
+        None
+    };
+
+    let mut terminal = ratatui::init();
+
+    let selected_hash = if let Some((ref items, ref meta_path, ref down_root)) = selection_data {
+        let (cmd_tx, _) = std::sync::mpsc::sync_channel(1);
+        let mut event_q: Queue<TorrentEvent, 512> = heapless::spsc::Queue::new();
+        let (_, event_rc) = event_q.split();
+        let (shutdown_signal_tx, _) = bounded(1);
+        let dht_paused = Arc::new(AtomicBool::new(false));
+
+        let mut selection_app = VortexApp::new(
+            cmd_tx,
+            event_rc,
+            shutdown_signal_tx,
+            Metadata::None,
+            down_root.clone(),
+            false,
+            dht_paused,
+            Some((
+                items.to_vec(),
+                meta_path.to_path_buf(),
+                down_root.to_path_buf(),
+            )),
+        );
+
+        selection_app.run(&mut terminal)?;
+        selection_app.selected_hash.clone()
+    } else {
+        None
+    };
+
+    if selection_data.is_some() && selected_hash.is_none() {
+        ratatui::restore();
+        return Ok(());
+    }
+
+    let torrent_info = if let Some(hash) = selected_hash {
         TorrentInfo {
-            info_hash: Some(selected_hash),
+            info_hash: Some(hash),
             magnet_link: None,
             torrent_file: None,
         }
@@ -513,6 +572,7 @@ impl<F> Widget for &mut VortexApp<'_, F> {
                     }
                 }
             }
+            AppState::SelectingTorrent { .. } => unreachable!(),
         };
 
         ProgressBar::new(progress_state).render(progress_area, buf);
@@ -549,7 +609,7 @@ impl<F> Widget for &mut VortexApp<'_, F> {
 
         InfoPanel::new(info_data).render(info_area, buf);
 
-        Footer { state: self.state }.render(footer_area, buf);
+        Footer { state: &self.state }.render(footer_area, buf);
     }
 }
 

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,29 +1,23 @@
 //! UI components for the TUI application.
 
-use std::{
-    path::PathBuf,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
 
-use clap::CommandFactory;
-use color_eyre::eyre::Result as EyreResult;
 use heapless::HistoryBuf;
 use human_bytes::human_bytes;
 use ratatui::{
-    DefaultTerminal, Frame,
-    crossterm::event::{self, Event, KeyCode, KeyEventKind},
-    layout::{Alignment, Constraint, Layout},
+    Frame,
+    layout::Alignment,
+    layout::{Constraint, Layout},
     prelude::{Buffer, Rect},
     style::{Color, Modifier, Style, Stylize, palette::tailwind},
     text::Span,
-    widgets::{
-        Axis, Block, Borders, Chart, Dataset, Gauge, List, ListItem, ListState, Paragraph, Row,
-        Table, Widget,
-    },
+    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, Row, Table, Widget},
+    widgets::{List, ListItem, ListState, Paragraph},
 };
+
 use vortex_bittorrent::MetadataProgress;
 
-use crate::{Cli, app::AppState};
+use crate::app::AppState;
 
 fn download_style() -> Style {
     Style::default().fg(Color::Green)
@@ -326,11 +320,11 @@ impl Widget for InfoPanel {
     }
 }
 
-pub struct Footer {
-    pub state: AppState,
+pub struct Footer<'a> {
+    pub state: &'a AppState,
 }
 
-impl Widget for Footer {
+impl Widget for Footer<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let key_style = Style::default()
             .fg(Color::Yellow)
@@ -365,91 +359,25 @@ pub fn extract_throughput_data(buf: &HistoryBuf<(f64, f64), 256>) -> Vec<(f64, f
     buf.oldest_ordered().copied().collect()
 }
 
-pub fn select_torrent(
-    metadata_path: PathBuf,
-    download_root: PathBuf,
-) -> EyreResult<Option<String>> {
-    std::fs::create_dir_all(&metadata_path)?;
-
-    let mut items = Vec::new();
-    for entry in std::fs::read_dir(&metadata_path)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let name_str = file_name.to_string_lossy();
-        if name_str.len() == 40 && name_str.chars().all(|c| c.is_ascii_hexdigit()) {
-            let hash = name_str.to_string();
-            let display_name = lava_torrent::torrent::v1::Torrent::read_from_file(entry.path())
-                .ok()
-                .map(|t| t.name)
-                .unwrap_or_else(|| hash.clone());
-
-            items.push((hash, display_name));
-        }
-    }
-
-    if items.is_empty() {
-        Cli::command().print_help().unwrap();
-        println!();
-        return Ok(None);
-    }
-
-    let mut terminal = ratatui::init();
-    let result = run_selection_menu(&mut terminal, items, metadata_path, download_root)?;
-    if result.is_none() {
-        ratatui::restore();
-    }
-    Ok(result)
+pub struct SelectionData<'a> {
+    pub items: &'a [(String, String)],
+    pub selected_index: usize,
+    pub delete_pending: bool,
+    pub pending_delete_index: Option<usize>,
 }
 
-struct SelectionState {
-    items: Vec<(String, String)>,
-    selected_index: usize,
-    should_quit: bool,
-    selected_hash: Option<String>,
-    delete_pending: bool,
-    pending_delete_index: Option<usize>,
-    metadata_path: PathBuf,
-    download_root: PathBuf,
-}
-
-pub fn run_selection_menu(
-    terminal: &mut DefaultTerminal,
-    items: Vec<(String, String)>,
-    metadata_path: PathBuf,
-    download_root: PathBuf,
-) -> EyreResult<Option<String>> {
-    let mut state = SelectionState {
-        items,
-        selected_index: 0,
-        should_quit: false,
-        selected_hash: None,
-        delete_pending: false,
-        pending_delete_index: None,
-        metadata_path,
-        download_root,
-    };
-
-    while !state.should_quit {
-        terminal.draw(|f| draw_selection(f, &state))?;
-        handle_selection_events(&mut state)?;
-    }
-
-    Ok(state.selected_hash)
-}
-
-fn draw_selection(frame: &mut Frame, state: &SelectionState) {
-    let area = frame.area();
+pub fn draw_torrent_selection(frame: &mut Frame, area: Rect, selection: &SelectionData) {
     let [list_area, help_area] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(area);
 
-    let list_items: Vec<ListItem> = state
+    let list_items: Vec<ListItem> = selection
         .items
         .iter()
         .map(|(_, name)| ListItem::new(name.as_str()))
         .collect();
 
     let mut list_state = ListState::default();
-    list_state.select(Some(state.selected_index));
+    list_state.select(Some(selection.selected_index));
 
     let list = List::new(list_items)
         .block(Block::bordered().title("Select a torrent"))
@@ -458,11 +386,11 @@ fn draw_selection(frame: &mut Frame, state: &SelectionState) {
 
     frame.render_stateful_widget(list, list_area, &mut list_state);
 
-    let help_text = if state.delete_pending {
-        format!(
-            "Delete '{}'? (y/n)",
-            state.items[state.pending_delete_index.unwrap_or(state.selected_index)].1
-        )
+    let help_text = if selection.delete_pending {
+        let idx = selection
+            .pending_delete_index
+            .unwrap_or(selection.selected_index);
+        format!("Delete '{}'? (y/n)", selection.items[idx].1)
     } else {
         "↑/↓: navigate, Enter: select, d: delete, q: quit".to_string()
     };

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -5,13 +5,12 @@ use std::time::{Duration, SystemTime};
 use heapless::HistoryBuf;
 use human_bytes::human_bytes;
 use ratatui::{
-    Frame,
     layout::Alignment,
     layout::{Constraint, Layout},
     prelude::{Buffer, Rect},
     style::{Color, Modifier, Style, Stylize, palette::tailwind},
     text::Span,
-    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, Row, Table, Widget},
+    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, Row, StatefulWidget, Table, Widget},
     widgets::{List, ListItem, ListState, Paragraph},
 };
 
@@ -308,15 +307,15 @@ impl Widget for InfoPanel {
             ratatui::text::Text::styled(time_text, time_style),
         ]);
 
-        Table::new(vec![row], [ratatui::layout::Constraint::Fill(1); 5])
+        let table = Table::new(vec![row], [ratatui::layout::Constraint::Fill(1); 5])
             .header(Row::new(headers).style(default_style))
             .block(
                 Block::default()
                     .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
                     .border_type(ratatui::widgets::BorderType::Rounded),
             )
-            .style(default_style)
-            .render(area, buf);
+            .style(default_style);
+        Widget::render(table, area, buf);
     }
 }
 
@@ -361,142 +360,41 @@ pub fn extract_throughput_data(buf: &HistoryBuf<(f64, f64), 256>) -> Vec<(f64, f
 
 pub struct SelectionData<'a> {
     pub items: &'a [(String, String)],
-    pub selected_index: usize,
-    pub delete_pending: bool,
+    /// The item awaiting delete confirmation, if any
     pub pending_delete_index: Option<usize>,
 }
 
-pub fn draw_torrent_selection(frame: &mut Frame, area: Rect, selection: &SelectionData) {
-    let [list_area, help_area] =
-        Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(area);
+impl StatefulWidget for SelectionData<'_> {
+    type State = ListState;
 
-    let list_items: Vec<ListItem> = selection
-        .items
-        .iter()
-        .map(|(_, name)| ListItem::new(name.as_str()))
-        .collect();
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let [list_area, help_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(area);
 
-    let mut list_state = ListState::default();
-    list_state.select(Some(selection.selected_index));
-
-    let list = List::new(list_items)
+        let list = List::new(
+            self.items
+                .iter()
+                .map(|(_, name)| ListItem::new(name.as_str())),
+        )
         .block(Block::bordered().title("Select a torrent"))
         .highlight_style(Style::new().bg(Color::Yellow).fg(Color::Black))
         .highlight_symbol(">> ");
 
-    frame.render_stateful_widget(list, list_area, &mut list_state);
+        // Rendering the list clamps an out of bounds selection back into range and
+        // updates the scroll offset, so the state must outlive the frame.
+        StatefulWidget::render(list, list_area, buf, state);
 
-    let help_text = if selection.delete_pending {
-        let idx = selection
+        let help_text = match self
             .pending_delete_index
-            .unwrap_or(selection.selected_index);
-        format!("Delete '{}'? (y/n)", selection.items[idx].1)
-    } else {
-        "↑/↓: navigate, Enter: select, d: delete, q: quit".to_string()
-    };
+            .and_then(|idx| self.items.get(idx))
+        {
+            Some((_, name)) => format!("Delete '{name}'? (y/n)"),
+            None => "↑/↓: navigate, Enter: select, d: delete, q: quit".to_string(),
+        };
 
-    let help = Paragraph::new(help_text)
-        .block(Block::bordered())
-        .alignment(Alignment::Center);
-    frame.render_widget(help, help_area);
-}
-
-fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
-    if event::poll(Duration::from_millis(16))?
-        && let Event::Key(key) = event::read()?
-        && key.kind == KeyEventKind::Press
-    {
-        if state.delete_pending {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    let idx = state.pending_delete_index.unwrap_or(state.selected_index);
-                    let (hash, name) = &state.items[idx];
-
-                    let base_name = if name.is_empty() {
-                        hash.as_str()
-                    } else {
-                        name.as_str()
-                    };
-                    let download_root = &state.download_root;
-
-                    let file_path = download_root.join(base_name);
-                    if file_path.exists() && file_path.is_file() {
-                        if let Err(e) = std::fs::remove_file(&file_path) {
-                            log::error!("Failed to delete file {}: {}", file_path.display(), e);
-                        } else {
-                            log::info!("Deleted file: {}", file_path.display());
-                        }
-                    }
-
-                    let dir_path = download_root.join(base_name);
-                    if dir_path.exists() && dir_path.is_dir() {
-                        if let Err(e) = std::fs::remove_dir_all(&dir_path) {
-                            log::error!("Failed to delete directory {}: {}", dir_path.display(), e);
-                        } else {
-                            log::info!("Deleted directory: {}", dir_path.display());
-                        }
-                    }
-
-                    let metadata_file = state.metadata_path.join(hash);
-                    if let Err(e) = std::fs::remove_file(&metadata_file) {
-                        log::error!(
-                            "Failed to delete metadata file {}: {}",
-                            metadata_file.display(),
-                            e
-                        );
-                    } else {
-                        log::info!("Deleted metadata file: {}", metadata_file.display());
-                    }
-
-                    state.items.remove(idx);
-
-                    if state.items.is_empty() {
-                        state.should_quit = true;
-                        return Ok(());
-                    }
-
-                    if state.selected_index >= state.items.len() {
-                        state.selected_index = state.items.len().saturating_sub(1);
-                    }
-
-                    state.delete_pending = false;
-                    state.pending_delete_index = None;
-                }
-                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
-                    state.delete_pending = false;
-                    state.pending_delete_index = None;
-                }
-                _ => {}
-            }
-        } else {
-            if state.items.is_empty() {
-                if let KeyCode::Char('q') = key.code {
-                    state.should_quit = true
-                }
-                return Ok(());
-            }
-            match key.code {
-                KeyCode::Up if state.selected_index > 0 => {
-                    state.selected_index -= 1;
-                }
-                KeyCode::Down if state.selected_index + 1 < state.items.len() => {
-                    state.selected_index += 1;
-                }
-                KeyCode::Enter => {
-                    let (hash, _) = state.items[state.selected_index].clone();
-                    state.selected_hash = Some(hash);
-                    state.should_quit = true;
-                }
-                KeyCode::Char('d') | KeyCode::Char('D') => {
-                    state.delete_pending = true;
-                    state.pending_delete_index = Some(state.selected_index);
-                }
-                KeyCode::Char('q') => {
-                    state.should_quit = true;
-                }
-                _ => {}
-            }
-        }
+        Paragraph::new(help_text)
+            .block(Block::bordered())
+            .alignment(Alignment::Center)
+            .render(help_area, buf);
     }
-    Ok(())
 }


### PR DESCRIPTION
Added `AppState::SelectingTorrent` to integrate the torrent selection menu into the main event loop. When no torrent source is given on the CLI, VortexApp starts directly in this state. This avoids duplicate terminal initialisation and raw‑mode corruption.

Note: Clippy warns about type_complexity and too_many_arguments in VortexApp::new. They don’t affect functionality; I can either suppress them or refactor – happy to do whatever you prefer.

Closes #128 

