### PR TITLE
feat: surface per-piece completion to clients

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1277,12 +1277,21 @@ fn report_tick_metrics(
 ) {
     let mut pieces_completed = 0;
     let mut pieces_allocated = 0;
+    let mut num_pieces = 0;
+    let mut piece_completion: Box<[u8]> = Box::default();
 
     if let Some(torrent_state) = state.state() {
         let total_completed = torrent_state.piece_selector.total_completed();
         let total_allocated = torrent_state.piece_selector.total_allocated();
         pieces_completed = total_completed;
         pieces_allocated = total_allocated;
+        num_pieces = torrent_state.num_pieces();
+        piece_completion = torrent_state
+            .piece_selector
+            .completed_clone()
+            .as_raw_slice()
+            .to_vec()
+            .into_boxed_slice();
         #[cfg(feature = "metrics")]
         {
             let counter = metrics::counter!("pieces_completed");
@@ -1305,6 +1314,8 @@ fn report_tick_metrics(
             pieces_completed,
             pieces_allocated,
             peer_metrics,
+            num_pieces,
+            piece_completion,
         })
         .is_err()
     {

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1275,29 +1275,18 @@ fn report_tick_metrics(
     _num_connections: usize,
     event_tx: &mut Producer<TorrentEvent>,
 ) {
-    let mut pieces_completed = 0;
     let mut pieces_allocated = 0;
-    let mut num_pieces = 0;
-    let mut piece_completion: Box<[u8]> = Box::default();
+    let mut progress = None;
 
     if let Some(torrent_state) = state.state() {
-        let total_completed = torrent_state.piece_selector.total_completed();
-        let total_allocated = torrent_state.piece_selector.total_allocated();
-        pieces_completed = total_completed;
-        pieces_allocated = total_allocated;
-        num_pieces = torrent_state.num_pieces();
-        piece_completion = torrent_state
-            .piece_selector
-            .completed_clone()
-            .as_raw_slice()
-            .to_vec()
-            .into_boxed_slice();
+        pieces_allocated = torrent_state.piece_selector.total_allocated();
+        progress = Some(torrent_state.piece_selector.progress());
         #[cfg(feature = "metrics")]
         {
             let counter = metrics::counter!("pieces_completed");
-            counter.absolute(total_completed as u64);
+            counter.absolute(torrent_state.piece_selector.total_completed() as u64);
             let gauge = metrics::gauge!("pieces_allocated");
-            gauge.set(total_allocated as u32);
+            gauge.set(pieces_allocated as u32);
             let gauge = metrics::gauge!("num_unchoked");
             gauge.set(torrent_state.num_unchoked);
         }
@@ -1311,11 +1300,9 @@ fn report_tick_metrics(
     }
     if event_tx
         .enqueue(TorrentEvent::TorrentMetrics {
-            pieces_completed,
             pieces_allocated,
             peer_metrics,
-            num_pieces,
-            piece_completion,
+            progress,
         })
         .is_err()
     {

--- a/bittorrent/src/lib.rs
+++ b/bittorrent/src/lib.rs
@@ -12,7 +12,10 @@ use peer_comm::*;
 pub use lava_torrent::torrent::v1::Torrent as TorrentMetadata;
 pub use peer_comm::extended_protocol::MetadataProgress;
 pub use peer_protocol::PeerId;
-pub use torrent::{CQE_WAIT_TIME_NS, Command, Config, PeerMetrics, State, Torrent, TorrentEvent};
+pub use torrent::{
+    CQE_WAIT_TIME_NS, Command, Config, PeerMetrics, ProgressIter, State, Torrent, TorrentEvent,
+    TorrentProgress,
+};
 
 #[cfg(feature = "fuzzing")]
 pub use peer_protocol::*;

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -2431,7 +2431,7 @@ fn metadata_extension_data_message() {
             .as_bytes()
             .to_vec();
         // Append some dummy metadata
-        data_msg.extend_from_slice(&vec![0u8; expected_size as usize]);
+        data_msg.extend_from_slice(&vec![0u8; expected_size]);
 
         connections[key_a].handle_message(
             PeerMessage::Extended {

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -252,16 +252,10 @@ impl PieceSelector {
     }
 
     /// Per-piece completion progress (downloaded *and* hash-verified),
-    /// built directly from the completed-piece bitfield.
+    /// built by cloning the completed-piece bitfield directly.
     #[inline]
     pub fn progress(&self) -> TorrentProgress {
-        TorrentProgress::new(
-            self.completed_pieces
-                .as_raw_slice()
-                .to_vec()
-                .into_boxed_slice(),
-            self.completed_pieces.len(),
-        )
+        TorrentProgress::new(self.completed_pieces.clone())
     }
 
     #[inline]

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -251,6 +251,13 @@ impl PieceSelector {
         self.downloaded_pieces.clone()
     }
 
+    /// A clone of the completed-piece bitfield (downloaded *and*
+    /// hash-verified). Bit `i` is set when piece `i` is complete.
+    #[inline]
+    pub fn completed_clone(&self) -> BitBox<u8, Msb0> {
+        self.completed_pieces.clone()
+    }
+
     #[inline]
     pub fn has_downloaded(&self, index: usize) -> bool {
         self.downloaded_pieces[index]

--- a/bittorrent/src/piece_selector.rs
+++ b/bittorrent/src/piece_selector.rs
@@ -10,7 +10,7 @@ use rand::SeedableRng;
 use rand::{RngExt, rngs::SmallRng};
 use slotmap::SecondaryMap;
 
-use crate::{buf_pool::Buffer, event_loop::ConnectionId};
+use crate::{buf_pool::Buffer, event_loop::ConnectionId, torrent::TorrentProgress};
 
 pub const SUBPIECE_SIZE: i32 = 16_384;
 
@@ -251,11 +251,17 @@ impl PieceSelector {
         self.downloaded_pieces.clone()
     }
 
-    /// A clone of the completed-piece bitfield (downloaded *and*
-    /// hash-verified). Bit `i` is set when piece `i` is complete.
+    /// Per-piece completion progress (downloaded *and* hash-verified),
+    /// built directly from the completed-piece bitfield.
     #[inline]
-    pub fn completed_clone(&self) -> BitBox<u8, Msb0> {
-        self.completed_pieces.clone()
+    pub fn progress(&self) -> TorrentProgress {
+        TorrentProgress::new(
+            self.completed_pieces
+                .as_raw_slice()
+                .to_vec()
+                .into_boxed_slice(),
+            self.completed_pieces.len(),
+        )
     }
 
     #[inline]

--- a/bittorrent/src/torrent.rs
+++ b/bittorrent/src/torrent.rs
@@ -197,25 +197,19 @@ pub struct PeerMetrics {
 /// completion state via [`TorrentProgress::iter`] (or `&progress` directly).
 #[derive(Debug, Clone)]
 pub struct TorrentProgress {
-    /// MSB0-packed completed-piece bitfield; bit `i`
-    /// (`completed[i / 8] & (0x80 >> (i % 8))`) is set when piece `i` is
-    /// complete. Length is `num_pieces.div_ceil(8)`.
-    completed: Box<[u8]>,
-    /// Total number of pieces in the torrent (the number of meaningful bits
-    /// in `completed`).
-    num_pieces: usize,
+    /// Completed-piece bitfield, one bit per piece: bit `i` is set when piece
+    /// `i` is complete. Its length equals the torrent's piece count.
+    completed: BitBox<u8, Msb0>,
     /// Cached count of completed pieces.
     completed_count: usize,
 }
 
 impl TorrentProgress {
-    /// Builds progress from an MSB0-packed bitfield of `num_pieces` pieces.
-    /// Bits beyond `num_pieces` (trailing padding) must be zero.
-    pub(crate) fn new(completed: Box<[u8]>, num_pieces: usize) -> Self {
-        let completed_count = completed.iter().map(|b| b.count_ones() as usize).sum();
+    /// Builds progress from the completed-piece bitfield (one bit per piece).
+    pub(crate) fn new(completed: BitBox<u8, Msb0>) -> Self {
+        let completed_count = completed.count_ones();
         Self {
             completed,
-            num_pieces,
             completed_count,
         }
     }
@@ -223,7 +217,7 @@ impl TorrentProgress {
     /// Total number of pieces in the torrent.
     #[inline]
     pub fn num_pieces(&self) -> usize {
-        self.num_pieces
+        self.completed.len()
     }
 
     /// Number of completed (downloaded and hash-verified) pieces.
@@ -236,19 +230,14 @@ impl TorrentProgress {
     /// indices.
     #[inline]
     pub fn get(&self, index: usize) -> bool {
-        index < self.num_pieces
-            && self
-                .completed
-                .get(index >> 3)
-                .is_some_and(|byte| byte & (0x80 >> (index & 7)) != 0)
+        self.completed.get(index).is_some_and(|bit| *bit)
     }
 
     /// Iterates over the completion state of every piece, in order.
     #[inline]
     pub fn iter(&self) -> ProgressIter<'_> {
         ProgressIter {
-            progress: self,
-            index: 0,
+            inner: self.completed.iter().by_vals(),
         }
     }
 }
@@ -265,26 +254,20 @@ impl<'a> IntoIterator for &'a TorrentProgress {
 /// Iterator over the per-piece completion state of a [`TorrentProgress`],
 /// yielding `true` for each complete piece and `false` otherwise.
 pub struct ProgressIter<'a> {
-    progress: &'a TorrentProgress,
-    index: usize,
+    inner: bitvec::slice::BitValIter<'a, u8, Msb0>,
 }
 
 impl Iterator for ProgressIter<'_> {
     type Item = bool;
 
+    #[inline]
     fn next(&mut self) -> Option<bool> {
-        if self.index < self.progress.num_pieces {
-            let value = self.progress.get(self.index);
-            self.index += 1;
-            Some(value)
-        } else {
-            None
-        }
+        self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.progress.num_pieces - self.index;
-        (remaining, Some(remaining))
+        self.inner.size_hint()
     }
 }
 
@@ -846,30 +829,31 @@ impl<'e_iter, 'state: 'e_iter> StateRef<'state> {
 #[cfg(test)]
 mod tests {
     use super::TorrentProgress;
+    use bitvec::prelude::{Msb0, bitbox};
 
     #[test]
     fn progress_get_is_msb0_and_bounds_checked() {
-        // 0b1010_0000 => pieces 0 and 2 complete, others clear.
-        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        // Pieces 0 and 2 complete, others clear.
+        let progress = TorrentProgress::new(bitbox![u8, Msb0; 1, 0, 1, 0]);
         assert!(progress.get(0));
         assert!(!progress.get(1));
         assert!(progress.get(2));
         assert!(!progress.get(3));
-        // Bits beyond num_pieces (padding) and out-of-range read as incomplete.
+        // Out-of-range indices read as incomplete.
         assert!(!progress.get(4));
         assert!(!progress.get(100));
     }
 
     #[test]
     fn progress_total_completed_counts_set_bits() {
-        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        let progress = TorrentProgress::new(bitbox![u8, Msb0; 1, 0, 1, 0]);
         assert_eq!(progress.num_pieces(), 4);
         assert_eq!(progress.total_completed(), 2);
     }
 
     #[test]
     fn progress_iter_yields_each_piece_in_order() {
-        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        let progress = TorrentProgress::new(bitbox![u8, Msb0; 1, 0, 1, 0]);
         let states: Vec<bool> = progress.iter().collect();
         assert_eq!(states, vec![true, false, true, false]);
         // `&progress` iterates too, and reports an exact length.
@@ -879,7 +863,7 @@ mod tests {
 
     #[test]
     fn empty_progress_has_no_pieces() {
-        let progress = TorrentProgress::new(Box::new([]), 0);
+        let progress = TorrentProgress::new(bitbox![u8, Msb0;]);
         assert_eq!(progress.num_pieces(), 0);
         assert_eq!(progress.total_completed(), 0);
         assert!(!progress.get(0));

--- a/bittorrent/src/torrent.rs
+++ b/bittorrent/src/torrent.rs
@@ -216,6 +216,20 @@ pub enum TorrentEvent {
         pieces_allocated: usize,
         /// Peer metrics for all currently connected peers
         peer_metrics: Vec<PeerMetrics>,
+        /// Total number of pieces in the torrent, or 0 if the torrent
+        /// has not been initialized yet (e.g. a magnet still fetching
+        /// metadata). Use this to know how many bits of
+        /// `piece_completion` are meaningful (the rest are padding).
+        num_pieces: usize,
+        /// Which pieces have been completed (downloaded and
+        /// hash-verified), as an MSB0-packed bitfield: bit `i`
+        /// (`piece_completion[i / 8] & (0x80 >> (i % 8))`) is set when
+        /// piece `i` is complete. Length is `num_pieces.div_ceil(8)`,
+        /// or empty when the torrent is not yet initialized. This is
+        /// populated both while downloading and by the startup hashing
+        /// scan in [`State::from_metadata_and_root`], so it is
+        /// meaningful immediately after a resume.
+        piece_completion: Box<[u8]>,
     },
 }
 
@@ -589,6 +603,27 @@ impl State {
         self.torrent_state
             .as_ref()
             .is_some_and(|state| state.is_complete)
+    }
+
+    /// Returns which pieces have been completed (downloaded and
+    /// hash-verified) as a `Vec<bool>` of length `num_pieces`, or
+    /// `None` if the torrent has not been initialized yet (e.g. a
+    /// magnet still fetching metadata).
+    ///
+    /// This reflects the startup hashing scan performed by
+    /// [`State::from_metadata_and_root`], so it is meaningful before
+    /// the event loop is started and is useful for inspecting on-disk
+    /// progress or for tests. During an active download, prefer the
+    /// `piece_completion` field of [`TorrentEvent::TorrentMetrics`].
+    pub fn completed_pieces(&self) -> Option<Vec<bool>> {
+        self.torrent_state.as_ref().map(|state| {
+            state
+                .piece_selector
+                .completed_clone()
+                .iter()
+                .by_vals()
+                .collect()
+        })
     }
 
     /// Use this constructor if you have access to the torrent metadata

--- a/bittorrent/src/torrent.rs
+++ b/bittorrent/src/torrent.rs
@@ -188,6 +188,108 @@ pub struct PeerMetrics {
     pub metadata_progress: Option<MetadataProgress>,
 }
 
+/// Per-piece download progress for a torrent: which pieces are complete
+/// (downloaded *and* hash-verified) and how many.
+///
+/// This hides the underlying MSB0-packed bitfield: query individual pieces
+/// with [`TorrentProgress::get`], the completed count with
+/// [`TorrentProgress::total_completed`], and iterate over every piece's
+/// completion state via [`TorrentProgress::iter`] (or `&progress` directly).
+#[derive(Debug, Clone)]
+pub struct TorrentProgress {
+    /// MSB0-packed completed-piece bitfield; bit `i`
+    /// (`completed[i / 8] & (0x80 >> (i % 8))`) is set when piece `i` is
+    /// complete. Length is `num_pieces.div_ceil(8)`.
+    completed: Box<[u8]>,
+    /// Total number of pieces in the torrent (the number of meaningful bits
+    /// in `completed`).
+    num_pieces: usize,
+    /// Cached count of completed pieces.
+    completed_count: usize,
+}
+
+impl TorrentProgress {
+    /// Builds progress from an MSB0-packed bitfield of `num_pieces` pieces.
+    /// Bits beyond `num_pieces` (trailing padding) must be zero.
+    pub(crate) fn new(completed: Box<[u8]>, num_pieces: usize) -> Self {
+        let completed_count = completed.iter().map(|b| b.count_ones() as usize).sum();
+        Self {
+            completed,
+            num_pieces,
+            completed_count,
+        }
+    }
+
+    /// Total number of pieces in the torrent.
+    #[inline]
+    pub fn num_pieces(&self) -> usize {
+        self.num_pieces
+    }
+
+    /// Number of completed (downloaded and hash-verified) pieces.
+    #[inline]
+    pub fn total_completed(&self) -> usize {
+        self.completed_count
+    }
+
+    /// Whether piece `index` is complete. Returns `false` for out-of-range
+    /// indices.
+    #[inline]
+    pub fn get(&self, index: usize) -> bool {
+        index < self.num_pieces
+            && self
+                .completed
+                .get(index >> 3)
+                .is_some_and(|byte| byte & (0x80 >> (index & 7)) != 0)
+    }
+
+    /// Iterates over the completion state of every piece, in order.
+    #[inline]
+    pub fn iter(&self) -> ProgressIter<'_> {
+        ProgressIter {
+            progress: self,
+            index: 0,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a TorrentProgress {
+    type Item = bool;
+    type IntoIter = ProgressIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over the per-piece completion state of a [`TorrentProgress`],
+/// yielding `true` for each complete piece and `false` otherwise.
+pub struct ProgressIter<'a> {
+    progress: &'a TorrentProgress,
+    index: usize,
+}
+
+impl Iterator for ProgressIter<'_> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        if self.index < self.progress.num_pieces {
+            let value = self.progress.get(self.index);
+            self.index += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.progress.num_pieces - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ProgressIter<'_> {}
+
 /// Events from the torrent
 #[derive(Debug)]
 pub enum TorrentEvent {
@@ -209,27 +311,19 @@ pub enum TorrentEvent {
     Paused,
     /// Over all metrics for the torrent, sent every tick.
     TorrentMetrics {
-        /// How many pieces have currently been completed
-        pieces_completed: usize,
         /// How many pieces have been allocated by peers for
         /// download
         pieces_allocated: usize,
         /// Peer metrics for all currently connected peers
         peer_metrics: Vec<PeerMetrics>,
-        /// Total number of pieces in the torrent, or 0 if the torrent
-        /// has not been initialized yet (e.g. a magnet still fetching
-        /// metadata). Use this to know how many bits of
-        /// `piece_completion` are meaningful (the rest are padding).
-        num_pieces: usize,
-        /// Which pieces have been completed (downloaded and
-        /// hash-verified), as an MSB0-packed bitfield: bit `i`
-        /// (`piece_completion[i / 8] & (0x80 >> (i % 8))`) is set when
-        /// piece `i` is complete. Length is `num_pieces.div_ceil(8)`,
-        /// or empty when the torrent is not yet initialized. This is
-        /// populated both while downloading and by the startup hashing
-        /// scan in [`State::from_metadata_and_root`], so it is
-        /// meaningful immediately after a resume.
-        piece_completion: Box<[u8]>,
+        /// Per-piece completion progress (which pieces are complete and how
+        /// many), or `None` if the torrent has not been initialized yet
+        /// (e.g. a magnet still fetching metadata). Populated both while
+        /// downloading and by the startup hashing scan in
+        /// [`State::from_metadata_and_root`], so it is meaningful immediately
+        /// after a resume. Read the completed count via
+        /// [`TorrentProgress::total_completed`].
+        progress: Option<TorrentProgress>,
     },
 }
 
@@ -605,25 +699,21 @@ impl State {
             .is_some_and(|state| state.is_complete)
     }
 
-    /// Returns which pieces have been completed (downloaded and
-    /// hash-verified) as a `Vec<bool>` of length `num_pieces`, or
-    /// `None` if the torrent has not been initialized yet (e.g. a
-    /// magnet still fetching metadata).
+    /// Returns the per-piece completion progress (which pieces are complete
+    /// and how many), or `None` if the torrent has not been initialized yet
+    /// (e.g. a magnet still fetching metadata).
     ///
-    /// This reflects the startup hashing scan performed by
-    /// [`State::from_metadata_and_root`], so it is meaningful before
-    /// the event loop is started and is useful for inspecting on-disk
-    /// progress or for tests. During an active download, prefer the
-    /// `piece_completion` field of [`TorrentEvent::TorrentMetrics`].
-    pub fn completed_pieces(&self) -> Option<Vec<bool>> {
-        self.torrent_state.as_ref().map(|state| {
-            state
-                .piece_selector
-                .completed_clone()
-                .iter()
-                .by_vals()
-                .collect()
-        })
+    /// This is an at-rest accessor reflecting the startup hashing scan
+    /// performed by [`State::from_metadata_and_root`], so it is meaningful
+    /// *before* the event loop is started — useful for rendering accurate
+    /// progress for a resumed torrent without waiting for the first metrics
+    /// tick, and for inspecting on-disk progress or for tests. During an
+    /// active download the same information arrives via the `progress` field
+    /// of [`TorrentEvent::TorrentMetrics`].
+    pub fn progress(&self) -> Option<TorrentProgress> {
+        self.torrent_state
+            .as_ref()
+            .map(|state| state.piece_selector.progress())
     }
 
     /// Use this constructor if you have access to the torrent metadata
@@ -750,5 +840,49 @@ impl<'e_iter, 'state: 'e_iter> StateRef<'state> {
             .set(Box::new(metadata))
             .map_err(|_e| io::Error::other("State initialized twice"))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TorrentProgress;
+
+    #[test]
+    fn progress_get_is_msb0_and_bounds_checked() {
+        // 0b1010_0000 => pieces 0 and 2 complete, others clear.
+        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        assert!(progress.get(0));
+        assert!(!progress.get(1));
+        assert!(progress.get(2));
+        assert!(!progress.get(3));
+        // Bits beyond num_pieces (padding) and out-of-range read as incomplete.
+        assert!(!progress.get(4));
+        assert!(!progress.get(100));
+    }
+
+    #[test]
+    fn progress_total_completed_counts_set_bits() {
+        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        assert_eq!(progress.num_pieces(), 4);
+        assert_eq!(progress.total_completed(), 2);
+    }
+
+    #[test]
+    fn progress_iter_yields_each_piece_in_order() {
+        let progress = TorrentProgress::new(Box::new([0xA0]), 4);
+        let states: Vec<bool> = progress.iter().collect();
+        assert_eq!(states, vec![true, false, true, false]);
+        // `&progress` iterates too, and reports an exact length.
+        assert_eq!((&progress).into_iter().count(), 4);
+        assert_eq!(progress.iter().len(), 4);
+    }
+
+    #[test]
+    fn empty_progress_has_no_pieces() {
+        let progress = TorrentProgress::new(Box::new([]), 0);
+        assert_eq!(progress.num_pieces(), 0);
+        assert_eq!(progress.total_completed(), 0);
+        assert!(!progress.get(0));
+        assert_eq!(progress.iter().count(), 0);
     }
 }

--- a/bittorrent/tests/basic_download.rs
+++ b/bittorrent/tests/basic_download.rs
@@ -73,11 +73,7 @@ fn basic_seeded_download() {
                     TorrentEvent::MetadataComplete(_torrent) => {
                         log::info!("METADATA COMPLETE");
                     }
-                    TorrentEvent::TorrentMetrics {
-                        pieces_completed: _,
-                        pieces_allocated: _,
-                        peer_metrics: _,
-                    } => {}
+                    TorrentEvent::TorrentMetrics { .. } => {}
                     TorrentEvent::Running { port: _ } => {}
                     TorrentEvent::Paused => panic!("Should never pause"),
                 }

--- a/bittorrent/tests/basic_seeding.rs
+++ b/bittorrent/tests/basic_seeding.rs
@@ -180,13 +180,13 @@ fn basic_seeding() {
                                 return;
                             }
                             TorrentEvent::TorrentMetrics {
-                                pieces_completed,
+                                progress,
                                 pieces_allocated,
                                 ..
                             } => {
                                 log::debug!(
                                     "Downloader progress: {}/{} pieces",
-                                    pieces_completed,
+                                    progress.as_ref().map_or(0, |p| p.total_completed()),
                                     pieces_allocated
                                 );
                             }

--- a/bittorrent/tests/chained_seeding.rs
+++ b/bittorrent/tests/chained_seeding.rs
@@ -201,11 +201,14 @@ fn chained_seeding() {
                             completed = true;
                         }
                         TorrentEvent::TorrentMetrics {
-                            pieces_completed,
+                            progress,
                             peer_metrics,
                             ..
                         } => {
-                            log::debug!("Middle peer progress: {}", pieces_completed,);
+                            log::debug!(
+                                "Middle peer progress: {}",
+                                progress.as_ref().map_or(0, |p| p.total_completed()),
+                            );
                             for metrics in peer_metrics {
                                 if metrics.upload_throughput > 0 {
                                     log::info!(
@@ -273,10 +276,11 @@ fn chained_seeding() {
                             seeder_shutting_down_clone.store(true, Ordering::Release);
                             return;
                         }
-                        TorrentEvent::TorrentMetrics {
-                            pieces_completed, ..
-                        } => {
-                            log::debug!("Leecher progress: {} pieces", pieces_completed,);
+                        TorrentEvent::TorrentMetrics { progress, .. } => {
+                            log::debug!(
+                                "Leecher progress: {} pieces",
+                                progress.as_ref().map_or(0, |p| p.total_completed()),
+                            );
                         }
                         TorrentEvent::MetadataComplete(_) => {
                             log::info!("Leecher: Metadata complete");

--- a/bittorrent/tests/pause_resume.rs
+++ b/bittorrent/tests/pause_resume.rs
@@ -158,10 +158,12 @@ fn pause_resume() {
                     while let Some(event) = downloader_event_rc.dequeue() {
                         match event {
                             TorrentEvent::TorrentMetrics {
-                                pieces_completed,
+                                progress,
                                 pieces_allocated,
                                 ..
                             } => {
+                                let pieces_completed =
+                                    progress.as_ref().map_or(0, |p| p.total_completed());
                                 log::debug!(
                                     "Downloader progress: {}/{} pieces (pause_sent={}, saw_paused={}, resume_sent={}, saw_resumed={})",
                                     pieces_completed,

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -201,8 +201,8 @@ impl<'queue> VortexApp<'queue> {
                 }
                 TorrentEvent::TorrentMetrics {
                     pieces_completed,
-                    pieces_allocated: _,
                     peer_metrics,
+                    ..
                 } => {
                     self.pieces_completed = pieces_completed;
                     self.num_connections = peer_metrics.len();

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -200,11 +200,11 @@ impl<'queue> VortexApp<'queue> {
                     });
                 }
                 TorrentEvent::TorrentMetrics {
-                    pieces_completed,
+                    progress,
                     peer_metrics,
                     ..
                 } => {
-                    self.pieces_completed = pieces_completed;
+                    self.pieces_completed = progress.as_ref().map_or(0, |p| p.total_completed());
                     self.num_connections = peer_metrics.len();
                     self.best_metadata_progress = peer_metrics
                         .iter()

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -548,15 +548,11 @@ fn handle_selection_events(state: &mut SelectionState) -> EyreResult<()> {
                 return Ok(());
             }
             match key.code {
-                KeyCode::Up => {
-                    if state.selected_index > 0 {
-                        state.selected_index -= 1;
-                    }
+                KeyCode::Up if state.selected_index > 0 => {
+                    state.selected_index -= 1;
                 }
-                KeyCode::Down => {
-                    if state.selected_index + 1 < state.items.len() {
-                        state.selected_index += 1;
-                    }
+                KeyCode::Down if state.selected_index + 1 < state.items.len() => {
+                    state.selected_index += 1;
                 }
                 KeyCode::Enter => {
                     let (hash, _) = state.items[state.selected_index].clone();


### PR DESCRIPTION
Expose which pieces are complete (downloaded and hash-verified), not just how many, so clients can render per-file progress and reliably tell a resumed-complete torrent from one that is still downloading.

- TorrentEvent::TorrentMetrics gains `num_pieces` and a `piece_completion` MSB0-packed bitfield, populated every tick from the completed-piece set (empty until the torrent is initialized).
- PieceSelector::completed_clone() exposes the completed bitfield.
- State::completed_pieces() -> Option<Vec<bool>> is an at-rest accessor reflecting the startup hashing scan, useful before the event loop starts and for tests.

Read-only and behavior-neutral: piece selection and download behavior are unchanged. See upstream discussion in Nehliin/vortex#134.