### PR TITLE
Support spawning the torrent threads later in cli lifecycle

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -56,11 +56,8 @@ impl Metadata {
     }
 }
 
-pub struct VortexApp<'queue> {
-    /// Command sender to the torrent event loop
-    pub cmd_tx: SyncSender<Command>,
-    /// Event receiver from the torrent event loop
-    pub event_rc: Consumer<'queue, TorrentEvent>,
+pub struct VortexApp<'queue, F> {
+    pub setup: AppSetup<'queue>,
     /// Flag to signal application shutdown
     pub should_exit: bool,
     /// Application start time for elapsed time calculations
@@ -73,40 +70,51 @@ pub struct VortexApp<'queue> {
     pub pieces_completed: usize,
     /// Number of active peer connections
     pub num_connections: usize,
-    /// Torrent metadata (available after metadata download)
-    pub metadata: Metadata,
     /// The progress for downloading metada from the furthest along peer
     pub best_metadata_progress: MetadataProgress,
-    /// Root directory for downloads
-    pub root: PathBuf,
     pub time_field: Time,
-    /// Signal sender to shutdown other threads
-    pub shutdown_signal_tx: Sender<()>,
     pub state: AppState,
-    pub dht_paused: Arc<AtomicBool>,
+    /// Used to kick of the vortex bittorrent threads
+    pub spawn_torrent_threads: Option<F>,
 }
 
-impl<'queue> VortexApp<'queue> {
-    pub fn new(
-        cmd_tx: SyncSender<Command>,
-        event_rc: Consumer<'queue, TorrentEvent>,
-        shutdown_signal_tx: Sender<()>,
-        metadata: Metadata,
-        root: PathBuf,
-        is_complete: bool,
-        dht_paused: Arc<AtomicBool>,
-    ) -> Self {
-        let state = if is_complete {
+impl<'queue, F> VortexApp<'queue, F> {
+    pub fn shutdown(&mut self) {
+        let _ = self.setup.cmd_tx.send(Command::Stop);
+        let _ = self.setup.shutdown_signal_tx.send(());
+        self.should_exit = true;
+    }
+}
+
+pub struct AppSetup<'queue> {
+    /// Command sender to the torrent event loop
+    pub cmd_tx: SyncSender<Command>,
+    /// Event receiver from the torrent event loop
+    pub event_rc: Consumer<'queue, TorrentEvent>,
+    /// Signal sender to shutdown other threads
+    pub shutdown_signal_tx: Sender<()>,
+    /// Torrent metadata (available after metadata download)
+    pub metadata: Metadata,
+    /// Root directory for downloads
+    pub root: PathBuf,
+    /// If the torrent is already downloaded
+    pub is_complete: bool,
+    /// Flag stating if the dht should pause or not
+    pub pause_dht: Arc<AtomicBool>,
+}
+
+impl<'queue, F: FnOnce()> VortexApp<'queue, F> {
+    pub fn new(setup: AppSetup<'queue>, spawn_torrent_threads: F) -> Self {
+        let state = if setup.is_complete {
             AppState::Seeding
-        } else if metadata.is_none() {
+        } else if setup.metadata.is_none() {
             AppState::DownloadingMetadata
         } else {
             AppState::Downloading
         };
 
         Self {
-            cmd_tx,
-            event_rc,
+            setup,
             should_exit: false,
             start_time: Instant::now(),
             pieces_completed: 0,
@@ -114,12 +122,9 @@ impl<'queue> VortexApp<'queue> {
             total_upload_throughput: Box::new(HistoryBuf::new()),
             num_connections: 0,
             best_metadata_progress: Default::default(),
-            metadata,
             time_field: Time::StartedAt(SystemTime::now()),
-            root,
-            shutdown_signal_tx,
+            spawn_torrent_threads: Some(spawn_torrent_threads),
             state,
-            dht_paused,
         }
     }
 
@@ -131,18 +136,19 @@ impl<'queue> VortexApp<'queue> {
         Ok(())
     }
 
-    pub fn shutdown(&mut self) {
-        let _ = self.cmd_tx.send(Command::Stop);
-        let _ = self.shutdown_signal_tx.send(());
-        self.should_exit = true;
-    }
-
     fn draw(&mut self, frame: &mut Frame) {
         frame.render_widget(self, frame.area());
     }
 
     pub fn handle_events(&mut self) -> io::Result<()> {
-        while let Some(event) = self.event_rc.dequeue() {
+        // Spawn the torrent threads the first time we reach the event handler.
+        // Keeping this here (rather than before the loop) means the spawning
+        // lives alongside the rest of the event handling and can later be gated
+        // on application state.
+        if let Some(spawn_torrent_threads) = self.spawn_torrent_threads.take() {
+            spawn_torrent_threads();
+        }
+        while let Some(event) = self.setup.event_rc.dequeue() {
             match event {
                 TorrentEvent::TorrentComplete => {
                     let download_time = match self.time_field {
@@ -157,7 +163,7 @@ impl<'queue> VortexApp<'queue> {
                         AppState::Paused { was_seeding, .. } => {
                             if was_seeding {
                                 AppState::Seeding
-                            } else if self.metadata.is_none() {
+                            } else if self.setup.metadata.is_none() {
                                 AppState::DownloadingMetadata
                             } else {
                                 AppState::Downloading
@@ -165,27 +171,27 @@ impl<'queue> VortexApp<'queue> {
                         }
                         AppState::Seeding => AppState::Seeding,
                         _ => {
-                            if self.metadata.is_none() {
+                            if self.setup.metadata.is_none() {
                                 AppState::DownloadingMetadata
                             } else {
                                 AppState::Downloading
                             }
                         }
                     };
-                    self.dht_paused.store(false, Ordering::Relaxed);
+                    self.setup.pause_dht.store(false, Ordering::Relaxed);
                 }
                 TorrentEvent::Paused => {
                     self.state = AppState::Paused {
                         was_seeding: matches!(self.state, AppState::Seeding),
                         last_simulated_update: Instant::now(),
                     };
-                    self.dht_paused.store(true, Ordering::Relaxed);
+                    self.setup.pause_dht.store(true, Ordering::Relaxed);
                 }
                 TorrentEvent::MetadataComplete(metadata) => {
-                    self.metadata = Metadata::Full(Box::new((*metadata).clone()));
+                    self.setup.metadata = Metadata::Full(Box::new((*metadata).clone()));
                     self.state = AppState::Downloading;
                     self.time_field = Time::StartedAt(SystemTime::now());
-                    let root = self.root.clone();
+                    let root = self.setup.root.clone();
                     // Store the metadata as the info hash in the download folder, that will
                     // ensure it's possible to recover from downloads that's already started
                     // The thread is used to keep this non blocking
@@ -255,17 +261,17 @@ impl<'queue> VortexApp<'queue> {
         match key_event.code {
             KeyCode::Char('q') => self.shutdown(),
             KeyCode::Char('p') if !matches!(self.state, AppState::Paused { .. }) => {
-                let _ = self.cmd_tx.send(Command::Pause);
+                let _ = self.setup.cmd_tx.send(Command::Pause);
             }
             KeyCode::Char('r') if matches!(self.state, AppState::Paused { .. }) => {
-                let _ = self.cmd_tx.send(Command::Resume);
+                let _ = self.setup.cmd_tx.send(Command::Resume);
             }
             _ => {}
         }
     }
 }
 
-impl Drop for VortexApp<'_> {
+impl<F> Drop for VortexApp<'_, F> {
     fn drop(&mut self) {
         self.shutdown();
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -419,7 +419,6 @@ fn main() -> color_eyre::Result<()> {
     let pause_dht = Arc::new(AtomicBool::new(false));
 
     let dht_cache_path = paths.dht_cache.clone();
-    let skip_dht_cache = cli.skip_dht_cache;
     std::thread::scope(|s| {
         let cmd_tx_clone = cmd_tx.clone();
         let pause_dht_clone = Arc::clone(&pause_dht);
@@ -435,7 +434,7 @@ fn main() -> color_eyre::Result<()> {
                     cmd_tx_clone,
                     shutdown_signal_rc,
                     dht_cache_path,
-                    skip_dht_cache,
+                    cli.skip_dht_cache,
                     pause_dht_clone,
                 )
                 .expect("DHT thread failed")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,7 +37,7 @@ use ui::{
 
 use mimalloc::MiMalloc;
 
-use crate::app::METADATA_DIR;
+use crate::app::{AppSetup, METADATA_DIR};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -404,7 +404,7 @@ fn main() -> color_eyre::Result<()> {
 
     let mut event_q: Queue<TorrentEvent, 512> = heapless::spsc::Queue::new();
 
-    let (command_tx, command_rc) = std::sync::mpsc::sync_channel(256);
+    let (cmd_tx, cmd_rc) = std::sync::mpsc::sync_channel(256);
     let (event_tx, event_rc) = event_q.split();
 
     let addr = format!("0.0.0.0:{}", vortex_config.port.unwrap_or_default());
@@ -416,37 +416,43 @@ fn main() -> color_eyre::Result<()> {
     let is_complete = state.is_complete();
     let mut torrent = Torrent::new(id, state);
     let (shutdown_signal_tx, shutdown_signal_rc) = bounded(1);
-    let dht_paused = Arc::new(AtomicBool::new(false));
+    let pause_dht = Arc::new(AtomicBool::new(false));
 
     let dht_cache_path = paths.dht_cache.clone();
+    let skip_dht_cache = cli.skip_dht_cache;
     std::thread::scope(|s| {
-        s.spawn(move || {
-            torrent.start(event_tx, command_rc, listener).unwrap();
-        });
-        let cmd_tx_clone = command_tx.clone();
-        let dht_paused_clone = Arc::clone(&dht_paused);
-        s.spawn(move || {
-            dht_thread(
-                info_hash_id,
-                port,
-                cmd_tx_clone,
-                shutdown_signal_rc,
-                dht_cache_path,
-                cli.skip_dht_cache,
-                dht_paused_clone,
-            )
-            .expect("DHT thread failed")
-        });
+        let cmd_tx_clone = cmd_tx.clone();
+        let pause_dht_clone = Arc::clone(&pause_dht);
+        // Use a closure to allow for spawning the torrent threads later in the cli lifecycle
+        let spawn_torrent_threads = move || {
+            s.spawn(move || {
+                torrent.start(event_tx, cmd_rc, listener).unwrap();
+            });
+            s.spawn(move || {
+                dht_thread(
+                    info_hash_id,
+                    port,
+                    cmd_tx_clone,
+                    shutdown_signal_rc,
+                    dht_cache_path,
+                    skip_dht_cache,
+                    pause_dht_clone,
+                )
+                .expect("DHT thread failed")
+            });
+        };
 
-        let mut app = VortexApp::new(
-            command_tx,
+        let setup = AppSetup {
+            cmd_tx,
             event_rc,
             shutdown_signal_tx,
             metadata,
             root,
             is_complete,
-            dht_paused,
-        );
+            pause_dht,
+        };
+
+        let mut app = VortexApp::new(setup, spawn_torrent_threads);
         let terminal = ratatui::init();
         let result = app.run(terminal);
         ratatui::restore();
@@ -454,7 +460,7 @@ fn main() -> color_eyre::Result<()> {
     })
 }
 
-impl Widget for &mut VortexApp<'_> {
+impl<F> Widget for &mut VortexApp<'_, F> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let [progress_area, graph_area, info_area, footer_area] = Layout::vertical([
             Constraint::Length(4),
@@ -470,7 +476,7 @@ impl Widget for &mut VortexApp<'_> {
             },
             AppState::Seeding => ProgressState::Seeding,
             AppState::Downloading => {
-                if let Metadata::Full(metadata) = &self.metadata {
+                if let Metadata::Full(metadata) = &self.setup.metadata {
                     let download_throughput = self
                         .total_download_throughput
                         .recent()
@@ -497,7 +503,7 @@ impl Widget for &mut VortexApp<'_> {
                 was_seeding: false, ..
             } => {
                 self.num_connections = 0;
-                if let Metadata::Full(metadata) = &self.metadata {
+                if let Metadata::Full(metadata) = &self.setup.metadata {
                     ProgressState::PausedDownloading {
                         pieces_completed: self.pieces_completed,
                         total_pieces: metadata.pieces.len(),
@@ -533,7 +539,7 @@ impl Widget for &mut VortexApp<'_> {
                 .map(|(_, v)| v)
                 .unwrap_or_default(),
             num_connections: self.num_connections,
-            name: match &self.metadata {
+            name: match &self.setup.metadata {
                 Metadata::Full(metadata) => metadata.name.clone(),
                 Metadata::Partial { name } => name.clone(),
                 Metadata::None => "Unknown".to_string(),


### PR DESCRIPTION
- Support starting the torrent + dht thread later in the the cli lifecycle to better support features like #133
- Merge args into an AppSetup struct
- Rename confusingly named `dht_paused` atomic flag 