### PR TITLE
perf: Improve snub recovery time

### DIFF
--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -505,6 +505,11 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             log::error!("Received unexpected piece message, index: {m_index}");
             return;
         };
+        let rtt = self.last_received_subpiece.take().unwrap().elapsed();
+        if rtt < self.request_timeout() && self.snubbed {
+            self.snubbed = false;
+        }
+
         if self.slow_start {
             self.update_target_inflight(self.target_inflight + 1);
         }
@@ -512,7 +517,6 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         self.network_stats.downloaded_in_last_round += length as u64;
         let request = self.inflight.remove(pos).unwrap();
         log::trace!("Subpiece completed: {}, {}", request.index, request.offset);
-        let rtt = self.last_received_subpiece.take().unwrap().elapsed();
         if !self.inflight.is_empty() {
             self.last_received_subpiece = Some(Instant::now());
         }

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -450,16 +450,19 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     pub fn request_timeout(&mut self) -> Duration {
+        const ADAPTIVE_TIMEOUT_CEILING: Duration = Duration::from_secs(40);
         let timeout_threshold = if self.moving_rtt.num_samples < 2 {
             if self.moving_rtt.num_samples == 0 {
-                Duration::from_secs(2)
+                ADAPTIVE_TIMEOUT_CEILING
             } else {
                 self.moving_rtt.mean() + self.moving_rtt.mean() / 5
             }
         } else {
             self.moving_rtt.mean() + (self.moving_rtt.average_deviation() * 4)
         };
-        timeout_threshold.max(Duration::from_secs(2))
+        let capped_timeout = timeout_threshold.min(ADAPTIVE_TIMEOUT_CEILING);
+        // Timeout floor
+        capped_timeout.max(Duration::from_secs(2))
     }
 
     fn push_subpiece_request(

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -1770,6 +1770,25 @@ fn snubbed_peer() {
             &mut pending_disk_operations,
             scope,
         );
+        // Still snubbed since adaptive timeout needs more samples haven't recovered yet
+        assert!(connections[key].snubbed);
+
+        // simulate the first piece arriving
+        let second = connections[key].inflight[0];
+        connections[key].handle_message(
+            PeerMessage::Piece {
+                index: second.index,
+                begin: second.offset,
+                data: vec![3; second.size as usize].into(),
+            },
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        // snub is cleared since it's within adaptive timeout
+        assert!(!connections[key].snubbed);
+        assert_eq!(connections[key].inflight.len(), 0);
+
         tick(
             &Duration::from_secs(1),
             &mut connections,
@@ -1777,7 +1796,7 @@ fn snubbed_peer() {
             &mut state_ref,
             &mut event_tx,
         );
-        assert!(!connections[key].snubbed);
+        // target is recalculated based off adaptive timeout
         assert!(connections[key].target_inflight > 1);
     });
 }

--- a/scripts/transmission_containers.sh
+++ b/scripts/transmission_containers.sh
@@ -113,7 +113,7 @@ then
         -v "${tr_watch_dir}:/watch:z" \
         -p 51413:51413 \
         --detach \
-        linuxserver/transmission
+        docker.io/linuxserver/transmission
 
     seed_ip="$(get_container_ip "${name}")"
     echo "Seed available on local net at IP: ${seed_ip}"


### PR DESCRIPTION
Previously vortex would only unsnub peers during the tick which runs every second. This meant we wasted potential bandwidth for peers who had already showed signed of recovery since the snubbed peers are limited to 1 inflight request at a time. This pr fixes that by unsnubbing as fast as possible directly in the message handler.

I've also capped the adaptive timeout window to maximum 40s, previously it was unbounded. Libtorrent uses 60s but I feel that is a bit too much.