### PR TITLE
feat: Add coarse grained stalled connection timeout

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1377,6 +1377,11 @@ pub(crate) fn tick<'scope, 'state: 'scope>(
                 // warn just to make more visible
                 log::warn!("Adaptive timeout: {}", connection.peer_id);
                 connection.on_request_timeout(torrent_state);
+            } else if connection.last_req_resp.elapsed() > Duration::from_secs(15)
+                && !connection.inflight.is_empty()
+            {
+                log::warn!("Stalled connection timeout: {}", connection.peer_id);
+                connection.on_request_timeout(torrent_state);
             }
             if !connection.peer_choking {
                 // slow start win size increase is handled in update_stats

--- a/bittorrent/src/peer_comm/peer_connection.rs
+++ b/bittorrent/src/peer_comm/peer_connection.rs
@@ -214,6 +214,8 @@ pub struct PeerConnection {
     // Time since last received subpiece request, used to timeout
     // requests
     pub last_received_subpiece: Option<Instant>,
+    // Time since any request/response at all
+    pub last_req_resp: Instant,
     pub slow_start: bool,
     pub snubbed: bool,
     // The averge time between pieces being received
@@ -287,6 +289,9 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             max_queue_size: 200,
             moving_rtt: Default::default(),
             pending_disconnect: None,
+            // this isn't totally accurate but doesn't matter
+            // when the connection is starting up
+            last_req_resp: Instant::now(),
             // We've just connected which is good enough as a last keep alive
             last_keepalive_sent: Instant::now(),
             network_stats: Default::default(),
@@ -441,6 +446,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
                     &mut self.outgoing_msgs_buffer,
                     &mut self.inflight,
                     &mut self.last_received_subpiece,
+                    &mut self.last_req_resp,
                     subpiece,
                 );
             } else {
@@ -450,7 +456,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
     }
 
     pub fn request_timeout(&mut self) -> Duration {
-        const ADAPTIVE_TIMEOUT_CEILING: Duration = Duration::from_secs(40);
+        const ADAPTIVE_TIMEOUT_CEILING: Duration = Duration::from_secs(45);
         let timeout_threshold = if self.moving_rtt.num_samples < 2 {
             if self.moving_rtt.num_samples == 0 {
                 ADAPTIVE_TIMEOUT_CEILING
@@ -469,6 +475,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         outgoing_msgs_buffer: &mut Vec<PeerMessage>,
         inflight: &mut VecDeque<Subpiece>,
         timeout_timer: &mut Option<Instant>,
+        req_resp_timer: &mut Instant,
         subpiece: Subpiece,
     ) {
         let subpiece_request = PeerMessage::Request {
@@ -477,9 +484,11 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             length: subpiece.size,
         };
         inflight.push_back(subpiece);
+        let time = Instant::now();
+        *req_resp_timer = time;
         // only if we didnt previously have
         if timeout_timer.is_none() {
-            *timeout_timer = Some(Instant::now());
+            *timeout_timer = Some(time);
         }
 
         outgoing_msgs_buffer.push(subpiece_request);
@@ -508,6 +517,8 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
             log::error!("Received unexpected piece message, index: {m_index}");
             return;
         };
+        let time = Instant::now();
+        self.last_req_resp = time;
         let rtt = self.last_received_subpiece.take().unwrap().elapsed();
         if rtt < self.request_timeout() && self.snubbed {
             self.snubbed = false;
@@ -521,7 +532,7 @@ impl<'scope, 'f_store: 'scope> PeerConnection {
         let request = self.inflight.remove(pos).unwrap();
         log::trace!("Subpiece completed: {}, {}", request.index, request.offset);
         if !self.inflight.is_empty() {
-            self.last_received_subpiece = Some(Instant::now());
+            self.last_received_subpiece = Some(time);
         }
         self.moving_rtt.add_sample(&rtt);
     }

--- a/bittorrent/src/peer_comm/tests.rs
+++ b/bittorrent/src/peer_comm/tests.rs
@@ -1984,6 +1984,69 @@ fn fast_ext_peer_rejecting_while_choked_is_not_snubbed() {
 }
 
 #[test]
+fn stalled_connection_is_snubbed() {
+    let mut download_state = setup_test();
+    let mut event_q = Queue::<TorrentEvent, 512>::new();
+    let (mut event_tx, _event_rx) = event_q.split();
+
+    rayon::in_place_scope(|scope| {
+        let mut state_ref = download_state.as_ref();
+        let mut pending_disk_operations: Vec<DiskOp> = Vec::new();
+        let mut connections = SlotMap::<ConnectionId, PeerConnection>::with_key();
+        let key = connections.insert_with_key(|k| generate_peer(true, k));
+        connections[key].handle_message(
+            PeerMessage::HaveAll,
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        // Hack to prevent the unchoke from auto-requesting so the inflight queue
+        // can be set up manually below.
+        connections[key].is_interesting = false;
+        connections[key].handle_message(
+            PeerMessage::Unchoke,
+            &mut state_ref,
+            &mut pending_disk_operations,
+            scope,
+        );
+        connections[key].is_interesting = true;
+
+        let torrent_state = state_ref.state().unwrap();
+        let index = torrent_state
+            .piece_selector
+            .next_piece(key, &mut connections[key].endgame)
+            .unwrap();
+        let mut subpieces = torrent_state.allocate_piece(index, key);
+        connections[key].append_and_fill(&mut subpieces);
+        assert!(!connections[key].inflight.is_empty());
+        assert!(!connections[key].snubbed);
+        assert!(connections[key].slow_start);
+
+        // No subpiece is ever delivered, so there are no rtt samples and the
+        // adaptive timeout sits at its ceiling, far above the stall window - it
+        // must NOT be what triggers here.
+        assert!(connections[key].request_timeout() > Duration::from_secs(16));
+
+        // The peer goes silent: no request sent and no response received for
+        // longer than the stall window. Both anchors age together, but only the
+        // coarse last_req_resp timer has elapsed.
+        connections[key].last_req_resp = Instant::now() - Duration::from_secs(16);
+        connections[key].last_received_subpiece = Some(Instant::now() - Duration::from_secs(16));
+
+        tick(
+            &Duration::from_secs(1),
+            &mut connections,
+            &Default::default(),
+            &mut state_ref,
+            &mut event_tx,
+        );
+        // The stall timeout fired and snubbed the peer (also dropping slow start).
+        assert!(connections[key].snubbed);
+        assert!(!connections[key].slow_start);
+    });
+}
+
+#[test]
 fn reject_request_requests_new() {
     let mut download_state = setup_test();
 


### PR DESCRIPTION
This mimics the behavior of libtorrent with some slight differences to the timing as well as what is considered "stalled". Vortex will for example not count invalid/unexpected piece requests where as libtorrent is a bit more lenient.

We basically just timeout connections that have not had any activity (either from us or the peer) in 15s when we have inflight requests. This is only relevant for slow connections that have a very large adaptive timeout window.