### PR TITLE
fix: Accept ENOENT for orphan CQEs from linked timeouts in event_loop

### DIFF
--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -47,7 +47,7 @@ const HANDSHAKE_TIMEOUT: Timespec = Timespec::new().sec(7);
 //     user_data), so the second CQE lands after the first removed the event;
 //   * a trailing CQE from a cancelled multishot recv. (ECANCELED)
 //
-// The linked-timeout half normally completes with ECANCELED but 
+// The linked-timeout half normally completes with ECANCELED but
 // may return  ENOENT in the race where the timer fires *and* the target completes
 // at nearly the same instant.
 fn is_expected_orphan_error(err: u32) -> bool {

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -45,18 +45,11 @@ const HANDSHAKE_TIMEOUT: Timespec = Timespec::new().sec(7);
 // Expected causes:
 //   * the linked-timeout half of a Recv/Connect + LinkTimeout pair (both share
 //     user_data), so the second CQE lands after the first removed the event;
-//   * a trailing CQE from a cancelled multishot recv.
+//   * a trailing CQE from a cancelled multishot recv. (ECANCELED)
 //
-// The linked-timeout half normally completes with ECANCELED (kernel path
-// `io_disarm_next`, both the pre-arm REQ_F_ARM_LTIMEOUT and post-arm
-// REQ_F_LINK_TIMEOUT branches use ECANCELED). ENOENT is the race where the
-// timer fires *and* the target completes at nearly the same instant: after
-// `io_link_timeout_fn` captures the target under the timeout lock, but before
-// `io_req_task_link_timeout` runs, the target is reaped. `io_try_cancel` then
-// returns -ENOENT and that becomes the linked-timeout CQE result via
-// `io_req_set_res(req, ret ?: -ETIME, 0)`. Reported as an undocumented return
-// value in liburing#1208 (https://github.com/axboe/liburing/issues/1208);
-// kernel source: io_uring/timeout.c io_req_task_link_timeout.
+// The linked-timeout half normally completes with ECANCELED but 
+// may return  ENOENT in the race where the timer fires *and* the target completes
+// at nearly the same instant.
 fn is_expected_orphan_error(err: u32) -> bool {
     matches!(err as i32, ECANCELED | ENOENT)
 }
@@ -595,11 +588,6 @@ impl<'scope, 'state: 'scope> EventLoop {
                     } else {
                         let err = io_event.result.unwrap_err();
                         // The event was already removed by an earlier CQE in this batch.
-                        // Legitimate causes (see `is_expected_orphan_error`):
-                        //  - the linked-timeout half of an IO_LINK'd Recv/Connect
-                        //    (both share user_data),
-                        //  - a trailing CQE from a multishot op (recv_multi) after we
-                        //    cancelled it and closed the socket.
                         assert!(
                             is_expected_orphan_error(err),
                             "unexpected orphan CQE errno {err} for event id {:?}",

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -17,7 +17,7 @@ use io_uring::{
     opcode,
     types::{self, CancelBuilder, Fd, Timespec},
 };
-use libc::ECANCELED;
+use libc::{ECANCELED, ENOENT};
 use rayon::Scope;
 use slotmap::{Key, KeyData, SlotMap, new_key_type};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -40,6 +40,26 @@ use crate::{
 
 const CONNECT_TIMEOUT: Timespec = Timespec::new().sec(10);
 const HANDSHAKE_TIMEOUT: Timespec = Timespec::new().sec(7);
+
+// A CQE is "orphan" when its event id has already been removed from `events`.
+// Expected causes:
+//   * the linked-timeout half of a Recv/Connect + LinkTimeout pair (both share
+//     user_data), so the second CQE lands after the first removed the event;
+//   * a trailing CQE from a cancelled multishot recv.
+//
+// The linked-timeout half normally completes with ECANCELED (kernel path
+// `io_disarm_next`, both the pre-arm REQ_F_ARM_LTIMEOUT and post-arm
+// REQ_F_LINK_TIMEOUT branches use ECANCELED). ENOENT is the race where the
+// timer fires *and* the target completes at nearly the same instant: after
+// `io_link_timeout_fn` captures the target under the timeout lock, but before
+// `io_req_task_link_timeout` runs, the target is reaped. `io_try_cancel` then
+// returns -ENOENT and that becomes the linked-timeout CQE result via
+// `io_req_set_res(req, ret ?: -ETIME, 0)`. Reported as an undocumented return
+// value in liburing#1208 (https://github.com/axboe/liburing/issues/1208);
+// kernel source: io_uring/timeout.c io_req_task_link_timeout.
+fn is_expected_orphan_error(err: u32) -> bool {
+    matches!(err as i32, ECANCELED | ENOENT)
+}
 
 #[derive(Debug)]
 pub enum EventType {
@@ -574,15 +594,17 @@ impl<'scope, 'state: 'scope> EventLoop {
                         }
                     } else {
                         let err = io_event.result.unwrap_err();
-                        // Only cancellation errors are expected here
-                        // since linked timeouts share event id with
-                        // the event being on a timer
-                        //
-                        // TODO: We might also end up here if we remove event id for a
-                        // reoccuring event like recv_multi even though we've cancelled
-                        // all events + close the socket if we've received multiple cqe for
-                        // the event in one submission
-                        assert_eq!(err as i32, ECANCELED);
+                        // The event was already removed by an earlier CQE in this batch.
+                        // Legitimate causes (see `is_expected_orphan_error`):
+                        //  - the linked-timeout half of an IO_LINK'd Recv/Connect
+                        //    (both share user_data),
+                        //  - a trailing CQE from a multishot op (recv_multi) after we
+                        //    cancelled it and closed the socket.
+                        assert!(
+                            is_expected_orphan_error(err),
+                            "unexpected orphan CQE errno {err} for event id {:?}",
+                            io_event.event_data_idx
+                        );
                     }
                     // Ensure bids are always returned
                     if let Some(bid) = io_event.read_bid {
@@ -1473,6 +1495,25 @@ mod tests {
     use metrics_util::{CompositeKey, MetricKind};
     use std::net::{SocketAddrV4, TcpListener};
     use std::time::Duration;
+
+    #[test]
+    fn orphan_cqe_rejects_other_errnos() {
+        for errno in [
+            libc::EFAULT,
+            libc::EINVAL,
+            libc::ECONNRESET,
+            libc::EPIPE,
+            libc::ETIME,
+            libc::ENOBUFS,
+            libc::EHOSTUNREACH,
+            libc::ECONNREFUSED,
+        ] {
+            assert!(
+                !is_expected_orphan_error(errno as u32),
+                "errno {errno} must not be accepted as an orphan CQE cause",
+            );
+        }
+    }
 
     #[test]
     #[cfg(feature = "metrics")]

--- a/bittorrent/src/event_loop.rs
+++ b/bittorrent/src/event_loop.rs
@@ -1485,25 +1485,6 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn orphan_cqe_rejects_other_errnos() {
-        for errno in [
-            libc::EFAULT,
-            libc::EINVAL,
-            libc::ECONNRESET,
-            libc::EPIPE,
-            libc::ETIME,
-            libc::ENOBUFS,
-            libc::EHOSTUNREACH,
-            libc::ECONNREFUSED,
-        ] {
-            assert!(
-                !is_expected_orphan_error(errno as u32),
-                "errno {errno} must not be accepted as an orphan CQE cause",
-            );
-        }
-    }
-
-    #[test]
     #[cfg(feature = "metrics")]
     fn handshake_timeout() {
         env_logger::builder()


### PR DESCRIPTION
Ref: #126 